### PR TITLE
Gosund WP3: Add Support For Blue LED

### DIFF
--- a/_devices/Gosund-WP3/Gosund-WP3.md
+++ b/_devices/Gosund-WP3/Gosund-WP3.md
@@ -6,16 +6,16 @@ standard: us
 ---
 
 1. TOC
-{:toc}
+   {:toc}
 
 ## GPIO Pinout
 
-| Pin     | Function                           |
-|---------|------------------------------------|
-| GPIO04  | Push Button inverted               |
-| GPIO12  | Red LED                            |
-| GPIO13  | Blue LED                           |
-| GPIO14  | Relay 1                            |
+| Pin    | Function             |
+| ------ | -------------------- |
+| GPIO04 | Push Button inverted |
+| GPIO12 | Red LED              |
+| GPIO13 | Blue LED             |
+| GPIO14 | Relay 1              |
 
 ## Basic Configuration
 
@@ -29,7 +29,6 @@ esphome:
   name: "${device_name}"
   platform: ESP8266
   board: esp01_1m
-
 
 wifi:
   ssid: !secret wifi_ssid
@@ -48,7 +47,7 @@ api:
 
 ota:
   password: !secret gosund_1_ota
-  
+
 binary_sensor:
   - platform: gpio
     pin:
@@ -72,18 +71,18 @@ switch:
       - output.turn_on: led
     on_turn_off:
       - output.turn_off: led
-      
+
 status_led:
   pin:
     number: GPIO12
     inverted: yes
-    
+
 output:
   - platform: gpio
     pin: GPIO13
     inverted: true
     id: led
-    
+
 sensor:
   - platform: wifi_signal
     name: "${friendly_name} WiFi signal"
@@ -98,3 +97,4 @@ text_sensor:
   - platform: version
     name: "${friendly_name} ESPHome Version"
     id: "${device_name}_esphome_version"
+```

--- a/_devices/Gosund-WP3/Gosund-WP3.md
+++ b/_devices/Gosund-WP3/Gosund-WP3.md
@@ -13,16 +13,20 @@ standard: us
 | Pin     | Function                           |
 |---------|------------------------------------|
 | GPIO04  | Push Button inverted               |
-| GPIO12  | Status LED                         |
+| GPIO12  | Red LED                            |
+| GPIO13  | Blue LED                           |
 | GPIO14  | Relay 1                            |
 
 ## Basic Configuration
 
 ```yaml
 ---
-# Basic Config
+substitutions:
+  device_name: gosund_wp3
+  friendly_name: Gosund WP3
+
 esphome:
-  name: gosund_1
+  name: "${device_name}"
   platform: ESP8266
   board: esp01_1m
 
@@ -31,52 +35,66 @@ wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 
-  manual_ip:
-    static_ip: !secret gosund_1_ip
-    gateway: !secret house_gateway
-    subnet: 255.255.255.0
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "${device_name} Fallback Hotspot"
+    password: !secret wifi_fallback_pw
 
 # Enable logging
 logger:
 
 # Enable Home Assistant API
 api:
-  password: !secret ha_esp_api_pw
 
 ota:
   password: !secret gosund_1_ota
   
-
 binary_sensor:
   - platform: gpio
     pin:
       number: GPIO4
       mode: INPUT_PULLUP
       inverted: True
-    name: "Gosund_1 button"
+    name: "${friendly_name} Button"
+    id: "${device_name}_button"
     on_press:
-      - switch.toggle: relay
+      - switch.toggle: "${device_name}_relay"
+  - platform: status
+    name: "${friendly_name} Status"
+    id: "${device_name}_status"
 
 switch:
   - platform: gpio
-    name: "Gosund_1 relay"
+    name: "${friendly_name} Relay"
+    id: "${device_name}_relay"
     pin: GPIO14
-    id: relay
-
+    on_turn_on:
+      - output.turn_on: led
+    on_turn_off:
+      - output.turn_off: led
+      
 status_led:
   pin:
     number: GPIO12
     inverted: yes
-
+    
+output:
+  - platform: gpio
+    pin: GPIO13
+    inverted: true
+    id: led
+    
 sensor:
   - platform: wifi_signal
-    name: "Gosund_1 WiFi signal"
+    name: "${friendly_name} WiFi signal"
+    id: "${device_name}_wifi_signal"
     update_interval: 60s
-
   - platform: uptime
-    name: "Gosund_1 uptime"
+    name: "${friendly_name} Uptime"
+    id: "${device_name}_uptime"
+    update_interval: 60s
 
 text_sensor:
   - platform: version
-    name: "Gosund_1 ESPHome version"
-```
+    name: "${friendly_name} ESPHome Version"
+    id: "${device_name}_esphome_version"


### PR DESCRIPTION
- Updated pinout table to contain blue led (`GPIO13`)
- Updated configuration to toggle `GPIO13` when relay is toggled, which is the stock firmware behavior.