### PR TITLE
Update Sonoff-Mini-Relay.md

### DIFF
--- a/_devices/Sonoff-Mini-Relay/Sonoff-Mini-Relay.md
+++ b/_devices/Sonoff-Mini-Relay/Sonoff-Mini-Relay.md
@@ -1,7 +1,7 @@
 ---
 title: Sonoff Mini Relay
 Model: IM190416001
-date-published: 2020-07-19
+date-published: 2020-11-19
 type: relay
 standard: global
 ---
@@ -42,6 +42,10 @@ wifi:
     static_ip: ${device_ip}
     gateway: 192.168.x.x
     subnet: 255.255.255.0
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "ESPHOME"
+    password: "12345678"
 
 logger:
   
@@ -51,6 +55,22 @@ api:
 
 ota:
   password: !secret ota_password
+
+# the web_server & sensor components can be removed without affecting core functionaility.
+
+web_server:
+  port: 80
+
+sensor:
+  - platform: wifi_signal
+    name: ${device_name} Wifi Signal Strength
+    update_interval: 60s
+  - platform: uptime
+    name: ${device_name} Uptime
+
+#######################################
+# Device specific Config Begins Below #
+#######################################
 
 binary_sensor:
   - platform: gpio
@@ -97,7 +117,121 @@ output:
     inverted: True
 
 light:
+  # the 4 lines below define the Blue LED light on Sonoff Mini, to expose in HomeAssistant remove line "internal: true"
   - platform: monochromatic
     name: ${device_name}_blueled
     output: blue_led
+    internal: true # hides the Blue LED from HomeAssistant
 ```
+
+## Alternative Config for Lights
+
+This config will cause the entities to appears as lights rather than switches in Home Assistant
+
+```yaml
+substitutions:
+  device_name: sonoffmini
+  device_ip: 192.168.x.x
+
+esphome:
+  name: ${device_name}
+  platform: ESP8266
+  board: esp01_1m
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  manual_ip:
+    static_ip: ${device_ip}
+    gateway: 192.168.0.1
+    subnet: 255.255.255.0
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "ESPHOME"
+    password: "12345678"
+
+logger:
+  
+api:
+  reboot_timeout: 15min
+  password: !secret api_password
+
+ota:
+  password: !secret ota_password
+
+# the web_server & sensor components can be removed without affecting core functionaility.
+
+web_server:
+  port: 80
+
+sensor:
+  - platform: wifi_signal
+    name: ${device_name} Wifi Signal Strength
+    update_interval: 60s
+  - platform: uptime
+    name: ${device_name} Uptime
+#######################################
+# Device specific Config Begins Below #
+#######################################
+
+binary_sensor:
+  # the 7 lines below define the reset button
+  - platform: gpio
+    pin: GPIO00
+    id: reset
+    internal: true  # hides reset switch from HomeAssistant
+    filters:
+      - invert:
+      - delayed_off: 10ms
+  # the 3 lines below toggle the main relay on press of reset button
+    on_press:
+      - light.toggle:
+          id: light_id
+
+  # the 13 lines below toggle the main relay on command
+  - platform: gpio
+    name: relay_toggle
+    internal: true  # hides relay toggle from HomeAssistant
+    pin: GPIO04
+    id: gpio_light_id
+    on_press:
+      then:
+        - light.toggle:
+            id: light_id
+    on_release:
+      then:
+        - light.toggle:
+            id: light_id
+
+  # the 2 lines below create a status entity in HomeAssistant.
+  - platform: status
+    name: ${device_name} Status
+
+status_led:
+  pin:
+    number: GPIO13
+    inverted: true
+
+output:
+  # the 3 lines below control the main relay
+  - platform: gpio
+    pin: GPIO12
+    id: main_light_relay  
+  # the 3 lines below control the Blue LED
+  - platform: esp8266_pwm
+    id: blue_led
+    pin: GPIO13
+    inverted: True
+
+light:
+  # the 4 lines below define the main relay as a light
+  - platform: binary
+    name: ${device_name}_light # you can enter a custom name to appear in HomeAsistant here.
+    output: main_light_relay  
+    id: light_id
+  # the 4 lines below define the Blue LED light on Sonoff Mini, to expose in HomeAssistant remove line "internal: true"
+  - platform: monochromatic
+    name: ${device_name}_blueled
+    output: blue_led
+    internal: true # hides the Blue LED from Homeassistant
+ ```


### PR DESCRIPTION
Added config that treats sonoff mini as a light.

Many people are using these relays to control light circuits. The Basic config creates switch entities which must be manually defined as lights. The new config I've added defines the relay as lights by default. I have also disabled the control of the blue LED light by default. Considering these devices are designed to be placed in hidden locations exposing this LED makes little sense.