### PR TITLE
Add color_interlock option for Novostella Flood 20w

### DIFF
--- a/_devices/Novostella-20W/Novostella-20W.md
+++ b/_devices/Novostella-20W/Novostella-20W.md
@@ -118,6 +118,7 @@ light:
   cold_white_color_temperature: 6500 K
   warm_white_color_temperature: 2700 K
   id: thelight
+  color_interlock: true #Prevent white leds being on at the same time as RGB leds
   restore_mode: ALWAYS_ON #Start with light on after reboot/power-loss event, so that it works from a dumb lightswitch
   effects:
     - random:
@@ -262,6 +263,7 @@ light:
   cold_white_color_temperature: 6500 K
   warm_white_color_temperature: 2700 K
   id: thelight
+  color_interlock: true #Prevent white leds being on at the same time as RGB leds
   restore_mode: ALWAYS_ON #Start with light on after reboot/power-loss event, so that it works from a dumb lightswitch
   effects:
     - random:


### PR DESCRIPTION
Hi there,

After version 1.14.3, the HA RGBWW slider of the white value jumps back to 0 when picking a color in color picker.
Setting color_interlock option seems to be needed for Novostella flood 20w.
The related issue [#1262](https://github.com/esphome/issues/issues/1262) on ESPHome project should be also closed by this PR.

Cheers!