### PR TITLE
Fix PC189HA example

### DIFF
--- a/_devices/Arlec-PC189HA-Plug/Arlec-PC189HA-Plug.md
+++ b/_devices/Arlec-PC189HA-Plug/Arlec-PC189HA-Plug.md
@@ -62,6 +62,7 @@ binary_sensor:
     pin:
       number: GPIO14
       inverted: True
+      mode: INPUT_PULLUP
     name: ${name} button
     filters:
       delayed_on_off: 100ms # Debouncing


### PR DESCRIPTION
INPUT_PULLUP went missing when copying the sample over the the repo from my own device config