### PR TITLE
ESP32-CAM: switch to PWM LED

### DIFF
--- a/_devices/ESP32-CAM/ESP32-CAM.md
+++ b/_devices/ESP32-CAM/ESP32-CAM.md
@@ -72,11 +72,12 @@ esp32_camera:
   idle_framerate: 0.1fps
 
 output:
-  - platform: gpio
+  - platform: ledc
     pin: GPIO4
-    id: gpio_4
+    channel: 2 # channel 1 is used for esp32_camera
+    id: led
 light:
-  - platform: binary
-    output: gpio_4
+  - platform: monochromatic
+    output: led
     name: espcam_02 light
 ```


### PR DESCRIPTION
It's possible to define ESP32-CAM LED as PWM, but to do so we need to use PWM channel 2, since channel 1 is used by the camera.