### PR TITLE
Fix and differentiate two similar model bulbs

### DIFF
--- a/src/docs/devices/Feit-BPA800-RGBW-AG-2(P)/index.md
+++ b/src/docs/devices/Feit-BPA800-RGBW-AG-2(P)/index.md
@@ -5,9 +5,7 @@ type: light
 standard: us
 ---
 
-Another Costco Variant
-
-**Do not confuse with Feit BPA800/RGBW/AG/2 as they use different GPIO pin numbers**
+Another Costco Variant. **Do not confuse with Feit BPA800/RGBW/AG/2 as they use different GPIO pin numbers.**
 
 Be warned that you will have to disassemble the device to flash the firmware if it is newer than about March 2020.
 Tuya changed their firmware such that tuya-convert no longer works as before.

--- a/src/docs/devices/Feit-BPA800-RGBW-AG-2/index.md
+++ b/src/docs/devices/Feit-BPA800-RGBW-AG-2/index.md
@@ -5,9 +5,7 @@ type: light
 standard: us
 ---
 
-Another Costco Variant
-
-**Do not confuse with Feit BPA800/RGBW/AG/2(P) as they use different GPIO pin numbers**
+Another Costco Variant. **Do not confuse with Feit BPA800/RGBW/AG/2(P) as they use different GPIO pin numbers.**
 
 Be warned that you will have to disassemble the device to flash the firmware if it is newer than about March 2020.
 Tuya changed their firmware such that tuya-convert no longer works as before.

--- a/src/docs/devices/Feit-BPA800-RGBW-AG-2/index.md
+++ b/src/docs/devices/Feit-BPA800-RGBW-AG-2/index.md
@@ -1,13 +1,13 @@
 ---
-title: Feit BPA800/RGBW/AG/2(P)
-date-published: 2020-12-01
+title: Feit BPA800/RGBW/AG/2
+date-published: 2021-05-11
 type: light
 standard: us
 ---
 
 Another Costco Variant
 
-**Do not confuse with Feit BPA800/RGBW/AG/2 as they use different GPIO pin numbers**
+**Do not confuse with Feit BPA800/RGBW/AG/2(P) as they use different GPIO pin numbers**
 
 Be warned that you will have to disassemble the device to flash the firmware if it is newer than about March 2020.
 Tuya changed their firmware such that tuya-convert no longer works as before.
@@ -43,15 +43,15 @@ substitutions:
    password: !secret api_pass
 
 sm16716:
-  data_pin: GPIO12
-  clock_pin: GPIO14
+  data_pin: GPIO14
+  clock_pin: GPIO4
   num_channels: 3
   num_chips: 1
 
 output:
   - platform: sm16716
     id: output_red
-    channel: 2
+    channel: 0
     power_supply: rgb_power
   - platform: sm16716
     id: output_green
@@ -59,11 +59,11 @@ output:
     power_supply: rgb_power
   - platform: sm16716
     id: output_blue
-    channel: 0
+    channel: 2
     power_supply: rgb_power
   - platform: esp8266_pwm
     id: output_warm_white
-    pin: GPIO04
+    pin: GPIO12
   - platform: esp8266_pwm
     id: output_cold_white
     pin: GPIO05
@@ -71,6 +71,8 @@ output:
 light:
   - platform: rgbww
     name: "${devicename}"
+    color_interlock: true
+    restore_mode: RESTORE_DEFAULT_OFF
     red: output_red
     green: output_green
     blue: output_blue
@@ -78,7 +80,6 @@ light:
     warm_white: output_warm_white
     cold_white_color_temperature: 6500 K
     warm_white_color_temperature: 2700 K
-    color_interlock: true
     gamma_correct: 0.0
 
 power_supply:


### PR DESCRIPTION
I'm the original submitter of the `2(P)` bulb docs, and I have some of the `2`, non-`(P)` bulbs as well. This is fully tested by me for both.