### PR TITLE
Add full support for DS03 speed levels

### DIFF
--- a/src/docs/devices/TreatLife-DS03/index.md
+++ b/src/docs/devices/TreatLife-DS03/index.md
@@ -77,4 +77,5 @@ fan:
     name: $friendly_name Speed
     switch_datapoint: 1
     speed_datapoint: 3
+    speed_count: 4
 ```


### PR DESCRIPTION
DS03 has four fan speeds, default is three.