### PR TITLE
Revert "Change invalid GPIO0 mode"

### DIFF
--- a/src/docs/devices/MJ-SJ01/index.md
+++ b/src/docs/devices/MJ-SJ01/index.md
@@ -133,7 +133,7 @@ binary_sensor:
     pin:
       number: GPIO0
       inverted: True
-      mode: INPUT
+      mode: INPUT_PULLUP
     name: ${friendly_name} Up Button
     id: up_button
     internal: True


### PR DESCRIPTION
Reverts esphome-devices/esphome-devices#149

Today I've learned that this was a mistake and the error was being thrown for the wrong pin.

https://github.com/esphome/esphome-docs/pull/1552#pullrequestreview-785466901