### PR TITLE
Product now ships with incompatible WB3S chip

### DIFF
--- a/src/docs/devices/DETA-Grid-Connect-Smart-Switch/index.md
+++ b/src/docs/devices/DETA-Grid-Connect-Smart-Switch/index.md
@@ -11,6 +11,8 @@ The DETA [Smart Single Switch (6911HA)](https://www.bunnings.com.au/deta-smart-s
 
 [Triple 6903HA](https://www.bunnings.com.au/deta-smart-touch-activated-triple-gang-light-switch-with-grid-connect_p0161014) and [Quad 6904HA](https://www.bunnings.com.au/deta-smart-touch-activated-quad-gang-light-switch-with-grid-connect_p0161015) The pin outs on the 3 & 4 gang switches are different to the 1 and 2 gang switches.
 
+Deta/Bunnings now ship the Single and Double (tbc on Triple / Quad) with ESP WB3S chips, which are not compatible with ESPHome/Tuya/Tasmota/etc. Packaging states a "Series 2" model number, eg "6911HA - Series 2"
+
 ## GPIO Pinout
 
 | Pin    | Function                       |


### PR DESCRIPTION
Deta/Bunnings now selling these switches with incompatible ESP chip (WB3S). Including this in documentation as a warning.