### PR TITLE
New chip BL602 used instead of ESP for MagicHome devices

### DIFF
--- a/src/docs/devices/MagicHome-ZJ-WFMN-A-RGBW/index.md
+++ b/src/docs/devices/MagicHome-ZJ-WFMN-A-RGBW/index.md
@@ -11,6 +11,8 @@ MagicHome RGBW LED controller with Infrared (IR) receiver and remote.
 
 The IR codes are incomplete to map all remote functions to a button. Only ON/OFF, Red, Green, Blue, White, Flash and Strobe effects are implemented in this configuration
 
+:information_source: Please note that MagicHome began to produce devices with BL602 chip instead of ESP. ESPHome is not compatible with BL602. Before buying make sure a controller is using the right chip.
+
 ![alt text](/MagicHome-ZJ-WFMN-A-RGBW.png "MagicHome RGBW LED strip controller")
 
 ## GPIO Pinout


### PR DESCRIPTION
Warning about version 1.2 of PCB that uses BL602 instead of ESP.