### PR TITLE
Set GPIO16 to mode: INPUT

### DIFF
--- a/src/docs/devices/DETA-Grid-Connect-Smart-Switch/index.md
+++ b/src/docs/devices/DETA-Grid-Connect-Smart-Switch/index.md
@@ -111,7 +111,7 @@ binary_sensor:
   - platform: gpio
     pin:
       number: GPIO16
-      mode: INPUT_PULLUP
+      mode: INPUT
       inverted: True
     name: "${friendly_name} Top Button"
     #toggle relay on push
@@ -229,7 +229,7 @@ binary_sensor:
   - platform: gpio
     pin:
       number: GPIO16
-      mode: INPUT_PULLUP
+      mode: INPUT
       inverted: True
     name: "${friendly_name} 1st Button"
     #toggle relay on push
@@ -369,7 +369,7 @@ binary_sensor:
   - platform: gpio
     pin:
       number: GPIO16
-      mode: INPUT_PULLUP
+      mode: INPUT
       inverted: True
     name: "${friendly_name} 1st Button"
     #toggle relay on push


### PR DESCRIPTION
As per this comment, https://github.com/esphome/issues/issues/2675#issuecomment-959002147, 
set GPIO16 to mode: INPUT as INPUT_PULLUP is not supported.