### PR TITLE
Fix template that uses binary sensor on output pin

### DIFF
--- a/src/docs/devices/Aukey-SH-PA1-Smart-Plug/index.md
+++ b/src/docs/devices/Aukey-SH-PA1-Smart-Plug/index.md
@@ -67,7 +67,6 @@ light:
       - light.turn_on: blue_led
     on_turn_off:
       - light.turn_off: blue_led
-    
   - platform: binary
     id: blue_led
     output: blue_led_output

--- a/src/docs/devices/Aukey-SH-PA1-Smart-Plug/index.md
+++ b/src/docs/devices/Aukey-SH-PA1-Smart-Plug/index.md
@@ -56,13 +56,21 @@ output:
     pin:
       number: GPIO2
       inverted: yes
-    id: blue_led
+    id: blue_led_output
 
 light:
   - platform: binary
     name: "Mini Tree"
     id: mini_tree
     output: plug_outlet
+    on_turn_on:
+      - light.turn_on: blue_led
+    on_turn_off:
+      - light.turn_off: blue_led
+    
+  - platform: binary
+    id: blue_led
+    output: blue_led_output
 
 binary_sensor:
   - platform: gpio
@@ -71,19 +79,6 @@ binary_sensor:
     id: mini_tree_button
     on_press:
       light.toggle: mini_tree
-
-  - platform: gpio
-    pin: GPIO15
-    id: blue_led_follows_the_relay
-    on_state:
-      then:
-        - if:
-            condition:
-              light.is_on: mini_tree
-            then:
-              - output.turn_on: blue_led
-            else:
-              - output.turn_off: blue_led
 
 status_led:
   # Red LED


### PR DESCRIPTION
The same pin should **not** be used for both an input and an output at the same time. 

Utilize ESPHome automations correctly to trigger another light/relay to follow state.

See esphome/issues#2865