### PR TITLE
Treatlife DS02S uses baudrate 115200

### DIFF
--- a/src/docs/devices/TreatLife-DS02S/index.md
+++ b/src/docs/devices/TreatLife-DS02S/index.md
@@ -11,9 +11,11 @@ Treatlife DS02S Switch![image](Treatlife-DS02S.png)
 
 ## Notes
 
-This TuyaMCU requires a baud rate of 9600, unlike the DS03 dimmer.
+This TuyaMCU requires a baud rate of 9600 (see latest note on January 2022 for more info), unlike the DS03 dimmer.
 
 July 2021 - New device purchased now has Tuya WB3S Wifi Microcontroller in place of the previous TYWE3S, which is not ESP based. Luckily, the main board still has the appropriate footprint for an ESP-12F. Further instructions on how to swap microcontrollers can be found [here](https://community.home-assistant.io/t/treatlife-dual-outlet-indoor-dimmer-plug-wb3s-to-esp-12-transplant/256798)
+
+January 2022 - Newer models require a baudrate of 115200, similar to that of the DS03 dimmer. Like the DS03, it might say `Invalid baud_rate: Integration requested baud_rate 9600 but you have 115200!`, however this can be ignored.
 
 ## GPIO Pinout
 


### PR DESCRIPTION
Update docs to reflect that newer Treatlife DS02S devices require a baudrate of 115200 instead of the aforementioned 9600 baudrate.