### PR TITLE
DS-102 uses WB3S (non esp chips) now

### DIFF
--- a/src/docs/devices/Nameless-DS-102/index.md
+++ b/src/docs/devices/Nameless-DS-102/index.md
@@ -5,6 +5,10 @@ type: switch
 standard: eu
 ---
 
+## Warning 
+
+As of May 2022 these switches use a WB3S chip (BK7231T) and are no longer compatible with esphome!
+
 ## Notes
 
 - push button wall switch

--- a/src/docs/devices/Nameless-DS-102/index.md
+++ b/src/docs/devices/Nameless-DS-102/index.md
@@ -5,7 +5,7 @@ type: switch
 standard: eu
 ---
 
-## Warning 
+## Warning
 
 As of May 2022 these switches use a WB3S chip (BK7231T) and are no longer compatible with esphome!
 


### PR DESCRIPTION
As of May 2022 these switches use a WB3S chip (BK7231T) and are no longer compatible.