### PR TITLE
updated divider for voltage

### DIFF
--- a/src/docs/devices/Gosund-SP112/index.md
+++ b/src/docs/devices/Gosund-SP112/index.md
@@ -100,7 +100,7 @@ sensor:
     cf_pin: GPIO05
     cf1_pin: GPIO04
     current_resistor: 0.00221
-    voltage_divider: 871
+    voltage_divider: 775
     change_mode_every: 8
     update_interval: 10s
     current:


### PR DESCRIPTION
as per gosund sp111 device, the 775 value for voltage divider gives a much better voltage aproximation. (in my case from  275 to 245 which is 99,5% accurate)