### PR TITLE
Updating SP20 doc with alternative pinout

### DIFF
--- a/src/docs/devices/Teckin-SP20/index.md
+++ b/src/docs/devices/Teckin-SP20/index.md
@@ -19,6 +19,23 @@ standard: us
 | GPIO13 | Button            |
 | GPIO4  | Relay             |
 
+## Alternate GPIO Pinout
+Unit from 2018/April (Amazon) had a diffent pinout. Visually, the QR code was on the "Live" plug side, and programming pins were slighlty different layout.
+
+Worth a try if standard pin out isn't working properly (relay will constantly click due sel_pin difference)
+
+| Pin    | Function          |
+| ------ | ----------------- |
+| GPIO0  | Status LED - Red  |
+| GPIO3  | sel_pin hlw8012   |
+| GPIO5  | cf_pin hlw8012    |
+| GPIO14 | cf1_pin hlw8012   |
+| GPIO15 | Status LED - Blue |
+| GPIO13 | Button            |
+| GPIO12 | Relay             |
+
+Basic configuration below assumes standard pinout, update accordingly if using alternate pinout.
+
 ## Basic Configuration
 
 ```yaml

--- a/src/docs/devices/Teckin-SP20/index.md
+++ b/src/docs/devices/Teckin-SP20/index.md
@@ -20,6 +20,7 @@ standard: us
 | GPIO4  | Relay             |
 
 ## Alternate GPIO Pinout
+
 Unit from 2018/April (Amazon) had a diffent pinout. Visually, the QR code was on the "Live" plug side, and programming pins were slighlty different layout.
 
 Worth a try if standard pin out isn't working properly (relay will constantly click due sel_pin difference)


### PR DESCRIPTION
Based on my own units, and looking around (Tasmota doc pages) I was able to flash and configure my SP20 units using an alternative pinout. 

This PR includes this alternate pinout in the configuration page to support others that might have same unit model/revision as me.