### PR TITLE
Modified wifi power save mode

### DIFF
--- a/src/docs/devices/Globe-4-Inch-9W-Downlight-50359/index.md
+++ b/src/docs/devices/Globe-4-Inch-9W-Downlight-50359/index.md
@@ -7,9 +7,9 @@ standard: us
 
 RGBWW smart light bulb, ultra slim recessed lighting kit, RGB colors + warm/cold white (2000K to 5000K), 120V AC 50/60Hz.
 
-This device uses an incompatible module `WB2S` which needs to be replaced with an ESP module. Besides the module, this process will require heat gun, soldering tools and moderate soldering skill.
+This device uses an incompatible module [WB2S](https://fcc.report/FCC-ID/2ANDL-WB2S/4580213.pdf "FCC") which needs to be replaced with an ESP module. Besides the module, this process will require heat gun, soldering tools and moderate soldering skill.
 
-Works with [WT32C3-01N](https://www.alibaba.com/product-detail/WT32C3-01N-4MB-OEM-ESP32-wi_1600348544006.html "Alibaba") module using the following template, but can work with others as well. This ESP32-C3 chip requires DIO flash mode to avoid boot loops. If encountering brown out issues with `rst:0xf (BROWNOUT_RST)`, then try using a dedicated 3V3 power supply with 28 guage or thicker wires (may need to be soldered).
+Works with [WT32C3-01N](https://www.alibaba.com/product-detail/WT32C3-01N-4MB-OEM-ESP32-wi_1600348544006.html "Alibaba") module using the following template, but can work with others as well. This ESP32-C3 chip requires DIO flash mode to avoid boot loops. If encountering brown out issues with `rst:0xf (BROWNOUT_RST)`, then try using a dedicated 3V3 power supply with 28 guage or thicker wires (may need to be soldered). All wifi power saving must be disabled with this module by including `power_save_mode: none`, reducing packet loss and average ping time from >1000ms to around 2-3ms on average.
 
 Constant Brightness (`constant_brightness`) is set to `true`. The original WB2S balances both white channels to combined 100% duty cycle.
 Color Interlock (`color_interlock`) is set to `true` as well. The original WB2S does not enable white and color leds at the same time.
@@ -80,6 +80,7 @@ esp32:
     type: esp-idf
 
 wifi:
+  power_save_mode: none
   ssid: !secret wifi_ssid
   password: !secret wifi_password
   ap:


### PR DESCRIPTION
Disable power save mode to reduce pings from >1000ms to 2ms (default "light"). It seems either the WT32N-01N (or the ESP32-C3 specifically) require power save mode to be disabled.

Before:
```
Reply from 10.xx.xx.xx: bytes=32 time=101ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=1236ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=2ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=106ms TTL=254
Request timed out.
Reply from 10.xx.xx.xx: bytes=32 time=3978ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=4ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=109ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=1339ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=2ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=614ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=1965ms TTL=254
```

After setting `power_save_mode: none`:
```
Reply from 10.xx.xx.xx: bytes=32 time=2ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=2ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=2ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=2ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=5ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=5ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=2ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=3ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=2ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=3ms TTL=254
Reply from 10.xx.xx.xx: bytes=32 time=4ms TTL=254
```