### PR TITLE
use status_led light platform; retain power status after power failure

### DIFF
--- a/src/docs/devices/Nous-A1t/index.md
+++ b/src/docs/devices/Nous-A1t/index.md
@@ -50,6 +50,7 @@ esphome:
 
 esp8266:
   board: esp8285
+  restore_from_flash: true
 
 # Enable logging
 logger:
@@ -79,10 +80,12 @@ time:
 web_server:
   port: 80
 
-status_led:
-  pin:
-    number: GPIO13
-    inverted: True
+light:
+  - platform: status_led
+    id: led
+    pin:
+      number: GPIO13
+      inverted: true
 
 binary_sensor:
   - platform: status
@@ -111,8 +114,10 @@ switch:
       }
     turn_on_action:
       - switch.turn_on: relay
+      - light.turn_on: led
     turn_off_action:
       - switch.turn_off: relay
+      - light.turn_off: led
   - platform: gpio
     pin: GPIO14
     id: relay


### PR DESCRIPTION
I really appreciate this configuration, it got me started in no-time with my new device.
There were 2 things that disturbed me a bit:
1) When unplugging the Nous and plugging it in again, it did not retain the power status, it always started with power off.
2) The status LED was nice to have when plugging in the Nous, showing that it was seeking for WiFi etc. But when fully started, the LED was off and did not indicate the power status.