### PR TITLE
Shelly Plus - fix value of NTC voltage divider resistor

### DIFF
--- a/src/docs/devices/Shelly-Plus-1/index.md
+++ b/src/docs/devices/Shelly-Plus-1/index.md
@@ -118,7 +118,7 @@ sensor:
     id: temp_resistance_reading
     sensor: temp_analog_reading
     configuration: DOWNSTREAM
-    resistor: 6kOhm
+    resistor: 10kOhm
   - platform: adc
     id: temp_analog_reading
     pin: GPIO32

--- a/src/docs/devices/Shelly-Plus-1PM/index.md
+++ b/src/docs/devices/Shelly-Plus-1PM/index.md
@@ -124,7 +124,7 @@ sensor:
     id: temp_resistance_reading
     sensor: temp_analog_reading
     configuration: DOWNSTREAM
-    resistor: 6kOhm
+    resistor: 10kOhm
   - platform: adc
     id: temp_analog_reading
     pin: GPIO32

--- a/src/docs/devices/Shelly-Plus-2PM/index.md
+++ b/src/docs/devices/Shelly-Plus-2PM/index.md
@@ -234,7 +234,7 @@ sensor:
     id: temp_resistance_reading
     sensor: temp_analog_reading
     configuration: DOWNSTREAM
-    resistor: 6kOhm
+    resistor: 10kOhm
 
   - platform: adc
     id: temp_analog_reading


### PR DESCRIPTION
Confirmed on Shelly Plus 1 - the actual value of desoldered resistor is 10kOhm. The incorrect value seems to be obtained by in-circuit measurement which is affected by other components. After this fix the measured temperature is much closer to expected values.

While tested only on Shelly Plus 1, it is most probably applicable to other Shelly devices sharing the same design.