### PR TITLE
Update Kogan Plug docs

### DIFF
--- a/src/docs/devices/Kogan-Smarterhome-Smart-Plug-Energy-Meter-5v-24a-Usb-Ports/index.md
+++ b/src/docs/devices/Kogan-Smarterhome-Smart-Plug-Energy-Meter-5v-24a-Usb-Ports/index.md
@@ -154,3 +154,21 @@ time:
   - platform: homeassistant
     id: homeassistant_time
 ```
+
+## Appendix
+If you are seeing incorrect power/current readings at higher power draws (i.e. current of 5A@240V while power is showing ~2000W), your unit most likely has a `BL0937` chip. You can verify this by looking at underside of the PCB, in the general area of the ESP chip. To get correct sensor results, make the following config changes:
+
+```yaml
+(...)
+substitutions:
+  current_res: "0.001" # visually verified the shunt resistor is 1m0
+  voltage_div: "1720" # rough value, tested against multimeter readout
+(...)
+sensor:
+  - platform: hlw8012
+    (...)
+    model: BL0937
+(...)
+```
+
+The readings should be correct from now on.

--- a/src/docs/devices/Kogan-Smarterhome-Smart-Plug-Energy-Meter-5v-24a-Usb-Ports/index.md
+++ b/src/docs/devices/Kogan-Smarterhome-Smart-Plug-Energy-Meter-5v-24a-Usb-Ports/index.md
@@ -121,35 +121,34 @@ sensor:
     update_interval: 5min
 
   - platform: uptime
-    id: uptime_sec
+    id: uptime_sensor
     name: "${device_name}_uptime"
     update_interval: 5min
+    on_raw_value:
+      then:
+        - text_sensor.template.publish:
+            id: uptime_human
+            state: !lambda |-
+              int seconds = round(id(uptime_sensor).raw_state);
+              int days = seconds / (24 * 3600);
+              seconds = seconds % (24 * 3600);
+              int hours = seconds / 3600;
+              seconds = seconds % 3600;
+              int minutes = seconds /  60;
+              seconds = seconds % 60;
+              return (
+                (days ? to_string(days) + "d " : "") +
+                (hours ? to_string(hours) + "h " : "") +
+                (minutes ? to_string(minutes) + "m " : "") +
+                (to_string(seconds) + "s")
+              ).c_str();
 
 text_sensor:
   - platform: template
-    name: "${device_name}_upformat"
-    lambda: |-
-      uint32_t dur = id(uptime_sec).state;
-      int dys = 0;
-      int hrs = 0;
-      int mnts = 0;
-      if (dur > 86399) {
-        dys = trunc(dur / 86400);
-        dur = dur - (dys * 86400);
-      }
-      if (dur > 3599) {
-        hrs = trunc(dur / 3600);
-        dur = dur - (hrs * 3600);
-      }
-      if (dur > 59) {
-        mnts = trunc(dur / 60);
-        dur = dur - (mnts * 60);
-      }
-      char buffer[17];
-      sprintf(buffer, "%ud %02uh %02um %02us", dys, hrs, mnts, dur);
-      return {buffer};
+    name: "${device_name}_uptime_human"
+    id: uptime_human
+    entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 5min
 
 time:
   - platform: homeassistant

--- a/src/docs/devices/Kogan-Smarterhome-Smart-Plug-Energy-Meter-5v-24a-Usb-Ports/index.md
+++ b/src/docs/devices/Kogan-Smarterhome-Smart-Plug-Energy-Meter-5v-24a-Usb-Ports/index.md
@@ -156,6 +156,7 @@ time:
 ```
 
 ## Appendix
+
 If you are seeing incorrect power/current readings at higher power draws (i.e. current of 5A@240V while power is showing ~2000W), your unit most likely has a `BL0937` chip. You can verify this by looking at underside of the PCB, in the general area of the ESP chip. To get correct sensor results, make the following config changes:
 
 ```yaml


### PR DESCRIPTION
- Added a section about the plug revision I personally had purchased which seems different to what the original page author worked with (current/power values were quite off for me when using values from the template config file)
- Updated uptime human sensor to be more reliable as the current one after boot always results in one erroneous sensor update with a very high uptime value.