### PR TITLE
Corrected value types for modbus OR-WE-514 energy meter

### DIFF
--- a/src/docs/devices/Orno-Single-Phase-Energy-meter-OR-WE-514/index.md
+++ b/src/docs/devices/Orno-Single-Phase-Energy-meter-OR-WE-514/index.md
@@ -181,7 +181,7 @@ sensor:
     register_type: holding
     address: 0xA000
     unit_of_measurement: "kWh"
-    value_type: U_WORD
+    value_type: U_DWORD
     accuracy_decimals: 2
     filters:
       - multiply: 0.01
@@ -192,7 +192,7 @@ sensor:
     register_type: holding
     address: 0xA01E
     unit_of_measurement: "kvarh"
-    value_type: U_WORD
+    value_type: U_DWORD
     accuracy_decimals: 2
     filters:
       - multiply: 0.01


### PR DESCRIPTION
Values at adresses 0xA0xx are all U_DWORD