### PR TITLE
Fix swapped UART GPIOs

### DIFF
--- a/src/docs/devices/Sonoff-BASIC-R2-v1.4/index.md
+++ b/src/docs/devices/Sonoff-BASIC-R2-v1.4/index.md
@@ -21,8 +21,8 @@ The red side of the LED cannot be individually controlled without modification t
 | GPIO0  | Push Button (HIGH = off, LOW = on) |
 | GPIO12 | Relay and its status LED           |
 | GPIO13 | Blue LED (HIGH = off, LOW = on)    |
-| GPIO1  | RX pin (for external sensors)      |
-| GPIO3  | TX pin (for external sensors)      |
+| GPIO3  | RX pin (for external sensors)      |
+| GPIO1  | TX pin (for external sensors)      |
 
 ## PCB
 


### PR DESCRIPTION
Looks like someone accidentally mixed up the UARTs GPIO pins.