### PR TITLE
Status led of Sonoff S20 is active low

### DIFF
--- a/src/docs/devices/Sonoff-S20/index.md
+++ b/src/docs/devices/Sonoff-S20/index.md
@@ -57,5 +57,7 @@ switch:
     id: relay
 
 status_led:
-  pin: GPIO13
+  pin:
+    number: GPIO13
+    inverted: true
 ```


### PR DESCRIPTION
Active low, hence it needs to be inverted