### PR TITLE
Added notice to the baud_rate

### DIFF
--- a/src/docs/devices/TreatLife-DS02S/index.md
+++ b/src/docs/devices/TreatLife-DS02S/index.md
@@ -60,7 +60,7 @@ web_server:
 uart:
   rx_pin: GPIO3
   tx_pin: GPIO1
-  baud_rate: 9600
+  baud_rate: 9600 #This may need to be 115200 See above in the notes
 
 tuya:
 


### PR DESCRIPTION
I had the issue that was noted above in the 'notes', but I didnt read it an only copy and pasted the yaml file.  this adds some comments so you see the issue in the yaml file. I think all new DS02S 3 way wifi dimmer's require 115200.  Maybe we should go ahead and set the default to 115200 instead of making it a note.