### PR TITLE
Fix User Button pin settings / correct battery voltage measurement

### DIFF
--- a/src/docs/devices/Waveshare-epaper-cloud-module/index.md
+++ b/src/docs/devices/Waveshare-epaper-cloud-module/index.md
@@ -41,7 +41,7 @@ Vendor documentation:
 ## Flashing
 
 Make sure you have a working driver installed for the CP2102 USB to serial convertor chip. I had problems with the stock MacOS Monterey one.
-After that simply connect to the USB-C port and flash as usual (in case of problems with enter programming mode, connect IO0 to GND, 
+After that simply connect to the USB-C port and flash as usual (in case of problems with enter programming mode, connect IO0 to GND,
 reset the device with reset button (EN) and keep the connection between GPIO0 and GND until programming starts).
 
 ## Device Specific Config
@@ -73,7 +73,7 @@ spi:
 
 binary_sensor:
   - platform: gpio
-    pin: 
+    pin:
       number: GPIO12
       inverted: true # user button pull IO12 to GND
       mode:          # pin as input and enable pull up

--- a/src/docs/devices/Waveshare-epaper-cloud-module/index.md
+++ b/src/docs/devices/Waveshare-epaper-cloud-module/index.md
@@ -24,7 +24,7 @@ Vendor documentation:
 |---------------|-------|-------------------------------------------------------------------------|
 | VCC           | VCC   | Power input (3.3V)                                                      |
 | GND           | GND   | GND                                                                     |
-| KEY           | 12    | User button                                                             |
+| KEY           | 12    | User button, Low active                                                 |
 | SCK           | 13    | CLK pin of SPI, clock input                                             |
 | DIN           | 14    | MOSI pin of SPI, data input                                             |
 | CS            | 15    | Chip select pin of SPI, Low active                                      |
@@ -41,7 +41,8 @@ Vendor documentation:
 ## Flashing
 
 Make sure you have a working driver installed for the CP2102 USB to serial convertor chip. I had problems with the stock MacOS Monterey one.
-After that simply connect to the USB-C port and flash as usual.
+After that simply connect to the USB-C port and flash as usual (in case of problems with enter programming mode, connect IO0 to GND, 
+reset the device with reset button (EN) and keep the connection between GPIO0 and GND until programming starts).
 
 ## Device Specific Config
 
@@ -61,6 +62,7 @@ sensor:
     id: battery_voltage
     icon: mdi:battery
     device_class: voltage
+    attenuation: auto # without attenuation the adc is saturated (VBat/3 > 1.1 V)
     filters:
      - multiply: 3
     update_interval: 60s
@@ -71,7 +73,12 @@ spi:
 
 binary_sensor:
   - platform: gpio
-    pin: GPIO12
+    pin: 
+      number: GPIO12
+      inverted: true # user button pull IO12 to GND
+      mode:          # pin as input and enable pull up
+        input: true
+        pullup: true
     name: "${devicename} button"
     filters:
       - delayed_on: 50ms


### PR DESCRIPTION
Since the user button does a pull to gnd when pressed, the pin must be inverted and configured as input with pull up.
An adc is saturated at ~1.1 V. but since the battery voltage can be >4 V (and thus at the pin >1.33 V) the adc is saturated without attenuation and the battery voltage in correct.
With the initial programming I had problems to initialize the programming mode. The description to the initial programming with my procedure extended