### PR TITLE
Update Sonoff S31 status pin to be inverted

### DIFF
--- a/src/docs/devices/Sonoff-S31/index.md
+++ b/src/docs/devices/Sonoff-S31/index.md
@@ -91,5 +91,7 @@ time:
     id: my_time
 
 status_led:
-  pin: GPIO13
+  pin:
+    number: GPIO13
+    inverted: True
 ```


### PR DESCRIPTION
Update the basic example for Sonoff S31 status pin to be inverted