### PR TITLE
Move board* to under esp8266 section

### DIFF
--- a/src/docs/devices/Sonoff-S26/index.md
+++ b/src/docs/devices/Sonoff-S26/index.md
@@ -20,6 +20,8 @@ standard: uk, us, eu, au
 esphome:
   name: sonoffs26_1
   platform: ESP8266
+  
+esp8266:
   board: esp01_1m
   board_flash_mode: dout
 


### PR DESCRIPTION
As of 2022.12 the syntax has changed. For me HA was requesting this change. The modified version works for me, so far.

Please merge this request.