### PR TITLE
Update GPIO for Mi Desklamp 1S

### DIFF
--- a/src/docs/devices/Mi-Desklamp-1S/index.md
+++ b/src/docs/devices/Mi-Desklamp-1S/index.md
@@ -77,8 +77,8 @@ sensor:
   # Mi Desk Lamp 1S Config
   - platform: rotary_encoder
     id: rotation
-    pin_a: GPIO26
-    pin_b: GPIO27
+    pin_a: GPIO27
+    pin_b: GPIO26
     resolution: 2
     on_value:
       then:


### PR DESCRIPTION
This update is because on my lamp, the GPIO was inverted with the sign on the lamp