### PR TITLE
Update TH3D-EZPlug-Plus to reduce relay bounce on restart

### DIFF
--- a/src/docs/devices/TH3D-EZPlug-Plus/index.md
+++ b/src/docs/devices/TH3D-EZPlug-Plus/index.md
@@ -30,6 +30,8 @@ esphome:
   name: TH3D_EZPlug_Plus
   platform: ESP8266
   board: esp01_1m
+  restore_from_flash: true
+  early_pin_init: true
 
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
I discovered my previous config suffered a serious bounce of the relay if it was on upon reboot, resulting in many devices losing power in the process.  The addition of restore_from_flash and early_pin_init to the esp8266 configuration has successfully mitigated that in my testing.