### PR TITLE
Swap parts of `led_red` variable name

### DIFF
--- a/src/docs/devices/Gosund-SP111/index.md
+++ b/src/docs/devices/Gosund-SP111/index.md
@@ -175,7 +175,7 @@ switch:
     id: button_switch
     turn_on_action:
       - switch.turn_on: relay
-      - output.turn_on: red_led
+      - output.turn_on: led_red
     turn_off_action:
       - switch.turn_off: relay
       - output.turn_off: led_red


### PR DESCRIPTION
In reference to `led_red` variable, the parts in its name were swapped. This was causing a compilation error.