### PR TITLE
Update Inkbird-ITC-308-WIFI.md

### DIFF
--- a/src/docs/devices/Inkbird-ITC-308-WIFI/Inkbird-ITC-308-WIFI.md
+++ b/src/docs/devices/Inkbird-ITC-308-WIFI/Inkbird-ITC-308-WIFI.md
@@ -14,7 +14,7 @@ The Inkbird ITC-308-WIFI is a wireless temperature controller that comes in a va
 
 ## WiFi Modules
 
-Older models ship with a Tuya TYWE3S module, which is an Espressif ESP8266-based module. Later models have replaced the module with the Tuya WBR3S module, utilizing the Realtek RTL8720DN chip. It's important to note that as of late 2023, LibreTiny, and therefore ESPHome, do not offer support for this particular chipset.  I have attempted to solder in an ESP12-S which is pin compatible, but whilst I was able to read the current temperature no other functions worked.
+Older models ship with a Tuya TYWE3S module, which is an Espressif ESP8266-based module. Later models have replaced the module with the Tuya WBR3S module, utilizing the Realtek RTL8720DN chip. It's important to note that as of late 2023, LibreTiny, and therefore ESPHome, do not offer support for this particular chipset.  It is possible to solder an ESP12-S which is pin compatible in place of the WBR3 module and everything works the same.
 
 ## Flashing
 


### PR DESCRIPTION
Previously I wasn't able to get an esp12 working in place of a WBR3 module, however I just hasn't connected TX correctly.  Updating the docs to state that it's possible.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
