### PR TITLE
Fix wrong url in Everything Presence One docs

### DIFF
--- a/src/docs/devices/Everything-Presence-One/index.md
+++ b/src/docs/devices/Everything-Presence-One/index.md
@@ -16,7 +16,7 @@ The Everything Presence One is a motion/occupancy sensor with the following feat
 - SHTC3 Temperature and Humidity sensor
 - BH1750 Light intensity sensor
 
-You can purchase a pre-built version from [https://shop.everythingsmart.io/en-au/products/everything-presence-one-kit](https://shop.everythingsmart.io/en-au/products/everything-presence-one-kit).
+You can purchase a pre-built version from [https://shop.everythingsmart.io/products/everything-presence-one-kit](https://shop.everythingsmart.io/products/everything-presence-one-kit).
 
 The full project yaml is available from the projects github: [https://github.com/EverythingSmartHome/everything-presence-one/blob/main/everything-presence-one.yaml](https://github.com/EverythingSmartHome/everything-presence-one/blob/main/everything-presence-one.yaml)
 


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
Fix wrong url in Everything Presence One docs,  since the old one gave a 404 not found error.
![image](https://github.com/user-attachments/assets/6247057d-6deb-4c32-baac-a5609259bbdb)



## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
