### PR TITLE
Update Sonoff-POW-Elite-20a/index.md

### DIFF
--- a/src/docs/devices/Sonoff-POW-Elite-20a/index.md
+++ b/src/docs/devices/Sonoff-POW-Elite-20a/index.md
@@ -50,6 +50,8 @@ esphome:
 
 esp32:
   board: nodemcu-32s
+  framework:
+    type: esp-idf
 
 wifi:
   ssid: !secret wifi_ssid
@@ -151,12 +153,9 @@ sensor:
                 (to_string(seconds) + "s")
               ).c_str();
 
-  - platform: template
-    name: $friendly_name ESP32 Internal Temp
-    device_class: temperature
-    unit_of_measurement: °C
+  - platform: internal_temperature
+    name: "$friendly_name ESP32 Internal Temp"
     id: esp32_temp
-    lambda: return temperatureRead();
 
   - platform: template
     name: $friendly_name Power Factor
@@ -164,13 +163,12 @@ sensor:
     id: power_factor
     lambda: return id(w_sensor).state / id(v_sensor).state / id(a_sensor).state;
 
-  - platform: esp32_hall
-    name: $friendly_name ESP32 Hall Sensor
-    update_interval: 60s
 
 binary_sensor:
   - platform: gpio
-    pin: GPIO00
+    pin:
+      number: GPIO00
+      ignore_strapping_warning: true
     id: reset
     internal: true
     filters:
@@ -196,7 +194,7 @@ binary_sensor:
                   state: ON
   - platform: template # this is a fake sensor to tell the screen which info to show on display
     id: page
-    publish_initial_state: true
+    trigger_on_initial_state: true
     internal: true
   - platform: template
     name: $friendly_name Load
@@ -225,7 +223,7 @@ display:
       it.display_kwh(false);
       it.printf(0, "%.1f", id(v_sensor).state);
       it.printf(1, "%.1f", id(a_sensor).state);
-    } else {  
+    } else {
       it.display_voltage(false);
       it.display_kwh(true);
       it.printf(0, "%.1f", id(wh_sensor).state);
@@ -262,7 +260,9 @@ switch:
     restore_mode: ALWAYS_OFF
     internal: true
     id: relay_on
-    pin: GPIO02
+    pin:
+      number: GPIO02
+      ignore_strapping_warning: true
     on_turn_on:
       - delay: 500ms
       - switch.turn_off: relay_on  # bi-stable relay so no need to keep on
@@ -270,6 +270,7 @@ switch:
     interlock: [relay_off]
   - platform: restart
     name: $friendly_name Restart
+
 
 text_sensor:
   - platform: template
@@ -295,6 +296,7 @@ light:
     pin:
       number: GPIO05
       inverted: True
+      ignore_strapping_warning: true
 
 interval:
   - interval: 30s


### PR DESCRIPTION

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Removed the hall sensor, as its deprecated. Changed to esp-idf framework because of limited flash memory, and moved to esp internal_temperature platform. Also added ignore for the strapping pins as this is a prebuilt unit. Also changed the deprecated publish_initial_state to its equivalent trigger_on_initial_state

## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
