### PR TITLE
Add moodlight instructions for newer Lanbon L8 version with WS2811 controller

### DIFF
--- a/src/docs/devices/lanbon_l8/index.md
+++ b/src/docs/devices/lanbon_l8/index.md
@@ -43,11 +43,11 @@ difficulty: 2
 
 ### Mood Light
 
-| Pin    | Function      |
-| ------ | ------------- |
-| GPIO26  | red   |
-| GPIO32  | green   |
-| GPIO33  | blue   |
+| Pin     | Function      | Newer devices   |
+| ------- | ------------- | --------------- |
+| GPIO26  | red           | controls WS2811 |
+| GPIO32  | green         | unused          |
+| GPIO33  | blue          | unused          |
 
 ### Relay (3-gang switch model)
 
@@ -92,16 +92,25 @@ output:
     id: relay_3
 
 light:
-  - platform: rgb
-    name: "Mood Light"
-    red: moodRed
-    green: moodGreen
-    blue: moodBlue
   - platform: monochromatic
     name: "Backlight"
     id: backlight
     output: backlight_pwm
     restore_mode: ALWAYS_ON
+  # Older devices use 3-channel RGB moodlight
+  - platform: rgb
+    name: "Mood Light"
+    red: moodRed
+    green: moodGreen
+    blue: moodBlue
+  # Newer devices use a WS2811 controller
+  # Make sure to disable the output on GPIO26
+  #- platform: esp32_rmt_led_strip
+  #  rgb_order: RGB
+  #  pin: GPIO26
+  #  num_leds: 8
+  #  chipset: ws2811
+  #  name: "Mood Light"
 
 spi:
   clk_pin: GPIO19


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Newer L8 devices do not use the 3-channel RGB moodlight anymore. Lanbon support confirmed: They have a WS2811 chip controlled with GPIO26. I have tested the changed configuration and it works on my device.


## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
