### PR TITLE
YAML configuration improvement for Xiaomi Philips Zhirui Downlight

### DIFF
--- a/src/docs/devices/Xiaomi-Philips-Zhirui-Downlight/index.md
+++ b/src/docs/devices/Xiaomi-Philips-Zhirui-Downlight/index.md
@@ -50,6 +50,7 @@ api:
 
 ota:
   password: !secret ota_password
+  platform: esphome
 
 output:
   - platform: esp8266_pwm


### PR DESCRIPTION
Added platform configuration to the OTA component.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

I have added the platform esphome setting to the OTA configuration, otherwise it won't compile with the new versions.

## Type of changes

- [ ] New device
- [X ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [ X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
