### PR TITLE
Add Add new FEIT outdoor plug variant Feit-PLUG-WIFI-WP-2

### DIFF
--- a/src/docs/devices/Feit-PLUG-WIFI-WP-2/index.md
+++ b/src/docs/devices/Feit-PLUG-WIFI-WP-2/index.md
@@ -17,7 +17,7 @@ Some versions of this 2 outlet versions shipped with ESP8266 boards, but this on
 bk72xx, as discussed
 [here](https://community.home-assistant.io/t/costco-feit-dual-outlet-outdoor-smart-plug/167786).
 
-Follow the steps in the great PLUG3 variant docs [here](/devices/Feit-PLUG3-WIFI-WP-2/) 
+Follow the steps in the great PLUG3 variant docs [here](/devices/Feit-PLUG3-WIFI-WP-2/)
 to flash your board via UART (the TX, RX, GND, and 3v3 pins are
 all clearly silk screened on the board in this variant) using ltchiptool.
 I lightly tack soldered to the pads,


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Add new FEIT outdoor plug variant with:
FCC ID: SYW-PLUGWFWP
IC: SYCZB-MW-AK


## Type of changes

- [X ] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [X ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
