### PR TITLE
1300 | Fixing wrong pins

### DIFF
--- a/src/docs/devices/Shelly-Plus-2PM/index.md
+++ b/src/docs/devices/Shelly-Plus-2PM/index.md
@@ -98,10 +98,10 @@ i2c:
 output:
   - platform: gpio
     id: "relay_output_1"
-    pin: GPIO12
+    pin: GPIO13
   - platform: gpio
     id: "relay_output_2"
-    pin: GPIO13
+    pin: GPIO12
 
 switch:
   - platform: output


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
There are wrong pins in minimal configuration for Shelly Plus 2PM.
This PR fixes issue https://github.com/esphome/esphome-devices/issues/1300 


## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
