### PR TITLE
Shelly Plus 1: Add pins for Shelly Plus Add-On

### DIFF
--- a/src/docs/devices/Shelly-Plus-1/index.md
+++ b/src/docs/devices/Shelly-Plus-1/index.md
@@ -62,11 +62,11 @@ logger:
 
 api:
   encryption:
-    key: !secret api_encryption_key
+    key: "" # Add your API encryption key here
 
 ota:
   - platform: esphome
-    password: !secret ota_password
+    password: "" # Add your OTA password here
 
 output:
   - platform: gpio
@@ -138,4 +138,5 @@ status_led:
   pin:
     number: GPIO0
     inverted: true
+    ignore_strapping_warning: true
 ```

--- a/src/docs/devices/Shelly-Plus-1/index.md
+++ b/src/docs/devices/Shelly-Plus-1/index.md
@@ -10,15 +10,17 @@ board: esp32
 
 ## GPIO Pinout
 
-| Pin    | Function                    |
-| ------ | --------------------------- |
-| GPIO0  | LED (Inverted)              |
-| GPIO4  | Switch input                |
-| GPIO19 | Future external sensors?    |
-| GPIO25 | Button (Inverted, Pull-up)  |
-| GPIO26 | Relay                       |
-| GPIO32 | NTC                         |
-| GPIO33 | Relay supply voltage sensor |
+| Pin    | Function                                          |
+| ------ | ------------------------------------------------- |
+| GPIO0  | LED (Inverted), Shelly Plus Add-On: DATA (Output) |
+| GPIO1  | Shelly Plus Add-On: DATA (Input)                  |
+| GPIO3  | Shelly Plus Add-On: ANALOG IN                     |
+| GPIO4  | Switch input                                      |
+| GPIO19 | Shelly Plus Add-On: DIGITAL IN                    |
+| GPIO25 | Button (Inverted, Pull-up)                        |
+| GPIO26 | Relay                                             |
+| GPIO32 | NTC                                               |
+| GPIO33 | Relay supply voltage sensor                       |
 
 The Shelly Plus 1 is based on the ESP32-U4WDH (Single core, 160MHz, 4MB embedded flash)
 


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
- Add pins for Shelly Plus Add-On
- Remove secret references
- Ignore GPIO0 strapping warning


## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
