### PR TITLE
Shelly Plus 2PM: Add pins for Shelly Plus Add-On

### DIFF
--- a/src/docs/devices/Shelly-Plus-2PM/index.md
+++ b/src/docs/devices/Shelly-Plus-2PM/index.md
@@ -87,8 +87,12 @@ esp32:
 logger:
 
 api:
+  encryption:
+    key: "" # Add your API encryption key here
 
 ota:
+  - platform: esphome
+    password: "" # Add your OTA password here
 
 wifi:
   ssid: !secret wifi_ssid
@@ -104,7 +108,9 @@ output:
     pin: GPIO13
   - platform: gpio
     id: "relay_output_2"
-    pin: GPIO12
+    pin:
+      number: GPIO12
+      ignore_strapping_warning: true
 
 switch:
   - platform: output
@@ -130,7 +136,9 @@ binary_sensor:
   # Input 1
   - platform: gpio
     name: "${input_name_1}"
-    pin: GPIO5
+    pin:
+      number: GPIO5
+      ignore_strapping_warning: true
     filters:
       - delayed_on_off: 50ms
     on_press:
@@ -262,9 +270,12 @@ logger:
 
 # Enable Home Assistant API
 api:
+  encryption:
+    key: "" # Add your API encryption key here
 
 ota:
-  password: !secret ota_password
+  - platform: esphome
+    password: "" # Add your OTA password here
 
 wifi:
   ssid: !secret wifi_ssid
@@ -273,7 +284,7 @@ wifi:
 
   ap:
     ssid: "${upper_devicename} fallback AP"
-    password: !secret fallback_password
+    password: "" # Add your fallback AP password here
 
 captive_portal:
 
@@ -291,7 +302,9 @@ output:
 
   - platform: gpio
     id: "relay_output_2"
-    pin: GPIO12
+    pin:
+      number: GPIO12
+      ignore_strapping_warning: true
 
 #Shelly Switch Output
 switch:
@@ -329,7 +342,9 @@ binary_sensor:
   #Shelly Switch Input 1
   - platform: gpio
     name: "${device_name_1} Input"
-    pin: GPIO5
+    pin:
+      number: GPIO5
+      ignore_strapping_warning: true
     #small delay to prevent debouncing
     filters:
       - delayed_on_off: 50ms
@@ -502,6 +517,7 @@ status_led:
   pin:
     number: GPIO0
     inverted: true
+    ignore_strapping_warning: true
  ```
 
 ## Current Based Cover Configuration Example for PCB v0.1.9 and Dual Core
@@ -549,13 +565,14 @@ logger:
 # Enable Home Assistant API
 api:
   encryption:
-    key: !secret api_key
+    key: "" # Add your API encryption key here
   on_client_disconnected: # failsafe
     then:
       - script.execute: blinds_open_if_no_manual_override
 
 ota:
-  password: !secret ota_password
+  - platform: esphome
+    password: "" # Add your OTA password here
 
 wifi:
   ssid: !secret wifi_ssid
@@ -568,7 +585,7 @@ wifi:
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "${devicename}-AP"
-    password: !secret ap_password
+    password: "" # Add your fallback AP password here
 
 captive_portal:
 
@@ -580,8 +597,8 @@ time:
 web_server:
   port: 80
   auth:
-    username: !secret web_server_username
-    password: !secret web_server_password
+    username: "" # Add your web server username here
+    password: "" # Add your web server password here
 
 
 i2c:
@@ -623,7 +640,9 @@ switch:
     interlock_wait_time: 200ms
   - platform: gpio
     id: "switch_close"
-    pin: GPIO12
+    pin:
+      number: GPIO12
+      ignore_strapping_warning: true
     internal: true
     restore_mode: ALWAYS_OFF
     interlock: [switch_open]
@@ -700,7 +719,9 @@ binary_sensor:
   - platform: gpio
     id: "input_open"
     name: "Open Input"
-    pin: GPIO5
+    pin:
+      number: GPIO5
+      ignore_strapping_warning: true
     #small delay for debouncing
     filters:
       - delayed_on_off: 50ms
@@ -866,6 +887,7 @@ status_led:
   pin:
     number: GPIO0
     inverted: true
+    ignore_strapping_warning: true
 
 text_sensor:
   - platform: wifi_info

--- a/src/docs/devices/Shelly-Plus-2PM/index.md
+++ b/src/docs/devices/Shelly-Plus-2PM/index.md
@@ -35,18 +35,21 @@ contains 8 characters starting with "H", the chip is single core 160MHz. If the 
 
 ## GPIO Pinout
 
-| Function                    | v0.1.5 | v0.1.9 |
-| --------------------------- | ------ | ------ |
-| LED (Inverted)              | GPIO0  | GPIO0  |
-| Button (Inverted, Pull-up)  | GPIO27 | GPIO4  |
-| Switch 1 Input              | GPIO2  | GPIO5  |
-| Switch 2 Input              | GPIO18 | GPIO18 |
-| Relay 1                     | GPIO13 | GPIO13 |
-| Relay 2                     | GPIO12 | GPIO12 |
-| I2C SCL                     | GPIO25 | GPIO25 |
-| I2C SDA                     | GPIO33 | GPIO26 |
-| ADE7953_IRQ (power meter)   | GPIO36 | GPIO27 |
-| Internal Temperature        | GPIO37 | GPIO35 |
+| Function                                          | v0.1.5 | v0.1.9 |
+| ------------------------------------------------- | ------ | ------ |
+| LED (Inverted), Shelly Plus Add-On: DATA (Output) | GPIO0  | GPIO0  |
+| Shelly Plus Add-On: DATA (Input)                  | GPIO1  | GPIO1  |
+| Shelly Plus Add-On: ANALOG IN                     | GPIO3  | GPIO3  |
+| Button (Inverted, Pull-up)                        | GPIO27 | GPIO4  |
+| Switch 1 Input                                    | GPIO2  | GPIO5  |
+| Switch 2 Input                                    | GPIO18 | GPIO18 |
+| Relay 1                                           | GPIO13 | GPIO13 |
+| Relay 2                                           | GPIO12 | GPIO12 |
+| Shelly Plus Add-On: DIGITAL IN                    | ?      | GPIO22 |
+| I2C SCL                                           | GPIO25 | GPIO25 |
+| I2C SDA                                           | GPIO33 | GPIO26 |
+| ADE7953_IRQ (power meter)                         | GPIO36 | GPIO27 |
+| Internal Temperature                              | GPIO37 | GPIO35 |
 
 ## Internal Temperature Sensor
 


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
- Add pins for Shelly Plus Add-On
- Remove secret references
- Ignore GPIO0, GPIO5 and GPIO12 strapping warning


## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
