### PR TITLE
Nous-A8T Fix: Contains an ESP32, not ESP32-C3

### DIFF
--- a/src/docs/devices/Nous-A8T/index.md
+++ b/src/docs/devices/Nous-A8T/index.md
@@ -10,8 +10,8 @@ difficulty: 3
 
 ## General Notes
 
-This device contains an ESP32-C3 and ships with Tasmota firmware.
-To flash it, the device can easily be disassembled by unscrewing the screw at the plug side.
+This device contains an ESP32 and ships with Tasmota firmware.
+To flash it, the device can be disassembled by unscrewing the screw in the hole at the bottom side of the plug.
 Alternatively, this procedure by kadam12g works as well—start at step 21: [https://github.com/kadam12g/ESPHome-Shelly-Plus-Plug-S?tab=readme-ov-file](https://github.com/kadam12g/ESPHome-Shelly-Plus-Plug-S?tab=readme-ov-file)
 
 ### Example Configuration
@@ -57,6 +57,7 @@ api:
 
 # Allow Over-The-Air updates
 ota:
+  - platform: esphome
 
 # Allow provisioning Wi-Fi via serial
 improv_serial:
@@ -94,6 +95,7 @@ light:
     pin:
       number: GPIO02
       inverted: true
+      ignore_strapping_warning: true
 
 binary_sensor:
   - platform: gpio


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
- Fix description: The Nous-A8T contains an ESP32. Both the ESPHome config below and the Tasmota version running on my A8T says `32`, not `32c3`
- Update instructions on how to open the device
- Add OTA platform
- Ignore strapping warning

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
