### PR TITLE
Add Novostella13W device configuration and YAML

### DIFF
--- a/src/docs/devices/novostella13w/index.md
+++ b/src/docs/devices/novostella13w/index.md
@@ -1,0 +1,152 @@
+---
+title: "Novostella13W"
+date-published: 2026-04-24
+type: light
+standard: us 
+board: esp8266
+---
+
+# Novostella13W
+
+<!-- Describe the device here. See the front-matter table on the contributing page for valid options. -->
+
+## Basic Configuration
+
+```yaml
+# Paste a working ESPHome YAML configuration here
+substitutions:
+  device_name: novoflood
+  device_description: 20W RGBWW flood light
+  friendly_name: Novostella Flood Light
+
+esphome:
+  name: ${device_name}
+  comment: ${device_description}
+
+esp8266:
+  board: esp01_1m
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  fast_connect: on #we only have one WiFi AP so just use the first one that matches
+  ap: #since we listed an SSID above, this AP mode will only enable if no WiFi connection could be made
+    ssid: ${friendly_name}_AP
+    password: !secret wifi_password
+
+captive_portal:
+
+# Enable logging
+logger:
+  baud_rate: 0 #disable UART logging since we aren't connected to GPIO1 TX
+
+# Enable Home Assistant API
+api:
+
+# Enable OTA updates
+ota:
+
+# Enable web server
+web_server:
+  port: 80
+
+binary_sensor:
+  # Reports if this device is Connected or not
+  - platform: status
+    name: ${friendly_name} Status
+
+sensor:
+  # Reports the WiFi signal strength
+  - platform: wifi_signal
+    name: ${friendly_name} Signal
+    update_interval: 60s
+
+  # Reports how long the device has been powered (in minutes)
+  - platform: uptime
+    name: ${friendly_name} Uptime
+    filters:
+      - lambda: return x / 60.0;
+    unit_of_measurement: minutes
+
+text_sensor:
+  # Reports the ESPHome Version with compile date
+  - platform: version
+    name: ${friendly_name} ESPHome Version
+
+output:
+  - platform: esp8266_pwm
+    id: red
+    pin: GPIO4
+    inverted: False
+  - platform: esp8266_pwm
+    id: green
+    pin: GPIO12
+    inverted: False
+  - platform: esp8266_pwm
+    id: blue
+    pin: GPIO14
+    inverted: False
+  - platform: esp8266_pwm
+    id: cold_white
+    pin: GPIO5
+    inverted: False
+  - platform: esp8266_pwm
+    id: warm_white
+    pin: GPIO13
+    inverted: False
+
+light:
+  - platform: rgbww
+    name: ${friendly_name}
+    red: red
+    green: green
+    blue: blue
+    cold_white: cold_white
+    warm_white: warm_white
+    cold_white_color_temperature: 6500 K
+    warm_white_color_temperature: 2700 K
+    id: thelight
+    color_interlock: true #Prevent white leds being on at the same time as RGB leds
+    restore_mode: ALWAYS_ON #Start with light on after reboot/power-loss event, so that it works from a dumb lightswitch
+    effects:
+      - random:
+      - strobe:
+      - flicker:
+          alpha: 50% #The percentage that the last color value should affect the light. More or less the “forget-factor” of an exponential moving average. Defaults to 95%.
+          intensity: 50% #The intensity of the flickering, basically the maximum amplitude of the random offsets. Defaults to 1.5%.
+      - lambda:
+          name: Throb
+          update_interval: 1s
+          lambda: |-
+            static int state = 0;
+            auto call = id(thelight).turn_on();
+            // Transtion of 1000ms = 1s
+            call.set_transition_length(1000);
+            if (state == 0) {
+              call.set_brightness(1.0);
+            } else {
+              call.set_brightness(0.01);
+            }
+            call.perform();
+            state += 1;
+            if (state == 2)
+              state = 0;
+
+# Blink the light if we aren't connected to WiFi.
+interval:
+  - interval: 500ms
+    then:
+      - if:
+          condition:
+            not:
+              wifi.connected:
+          then:
+            - light.turn_on:
+                id: thelight
+                brightness: 50%
+                transition_length: 0s
+            - delay: 250ms
+            - light.turn_off:
+                id: thelight
+                transition_length: 250ms
+```


### PR DESCRIPTION
Added configuration details for Novostella13W light device including type, standard, and board specifications. Updated YAML configuration for ESPHome with device-specific settings.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [ ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
