### PR TITLE
Alternative tool for removing the triangular-headed screws

### DIFF
--- a/src/docs/devices/Mirabella-Genio-Smart-Universal-IR-Controller/index.md
+++ b/src/docs/devices/Mirabella-Genio-Smart-Universal-IR-Controller/index.md
@@ -17,7 +17,9 @@ pull out the data pins and connect them to a USB UART like so (Note the colours 
 | 3 (Green)     | RXD          |
 
 To get into the boot loader it is necessary to short IO0 to ground. This requires opening the case which is uses
-triangular headed "security" screws, however these can be removed with a fine flat-head screw driver. Once open simply
+triangular headed "security" screws. These can be removed with a fine flat-head screw driver or a T7 Torx driver,
+however they can be very tight so a right-angled driver handle may be needed to apply sufficient torque to loosen them.
+Once open simply
 short the two pads "IO0" and "G" in the block of test points while powering the device on, then program with `esphome`.
 It would also be possible to solder to the test points, however they are fine pitched so using the cable simplifies
 things.


### PR DESCRIPTION
Updated instructions for opening the device case. Added details about using a T7 Torx driver and the possible need for a right-angled driver handle.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
Updated instructions for opening the device case based on my experience with this product:
1.  add alternative tool (T7 Torx driver);
2. mention the possible need for a right-angled driver handle to apply enough torque to loosen the screws.



## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [ ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
