### PR TITLE
Connect to the test points without cutting or soldering

### DIFF
--- a/src/docs/devices/Mirabella-Genio-Smart-Universal-IR-Controller/index.md
+++ b/src/docs/devices/Mirabella-Genio-Smart-Universal-IR-Controller/index.md
@@ -22,6 +22,11 @@ short the two pads "IO0" and "G" in the block of test points while powering the 
 It would also be possible to solder to the test points, however they are fine pitched so using the cable simplifies
 things.
 
+Another method is to use [jumper wires with DuPoint connectors](https://en.wikipedia.org/wiki/Jump_wire) inserted into the test points,
+alternating them so that adjacent connectors are inserted from opposite sides.
+This gives a tight fit and good electrical connections without any cutting or soldering. As well as the four wires for the USB UART adapter (V,G,TXD,RXD), also inserting one into IO0 and one into RST assists with entering boot mode. RST can be shorted to ground (G) instead of powering the device off and on.
+Note that the test point spacing is such that the round style of connectors fit well but the square profile connectors do not.
+
 ## GPIO Pinout
 
 | Pin    | Function           |

--- a/src/docs/devices/Mirabella-Genio-Smart-Universal-IR-Controller/index.md
+++ b/src/docs/devices/Mirabella-Genio-Smart-Universal-IR-Controller/index.md
@@ -22,10 +22,13 @@ short the two pads "IO0" and "G" in the block of test points while powering the 
 It would also be possible to solder to the test points, however they are fine pitched so using the cable simplifies
 things.
 
-Another method is to use [jumper wires with DuPoint connectors](https://en.wikipedia.org/wiki/Jump_wire) inserted into the test points,
-alternating them so that adjacent connectors are inserted from opposite sides.
-This gives a tight fit and good electrical connections without any cutting or soldering. As well as the four wires for the USB UART adapter (V,G,TXD,RXD), also inserting one into IO0 and one into RST assists with entering boot mode. RST can be shorted to ground (G) instead of powering the device off and on.
-Note that the test point spacing is such that the round style of connectors fit well but the square profile connectors do not.
+Another method is to use [jumper wires with DuPoint connectors](https://en.wikipedia.org/wiki/Jump_wire) inserted
+into the test points, alternating them so that adjacent connectors are inserted from opposite sides.
+This gives a tight fit and good electrical connections without any cutting or soldering. As well as the four wires
+for the USB UART adapter (V,G,TXD,RXD), also inserting one into IO0 and one into RST assists with entering boot mode.
+RST can be shorted to ground (G) instead of powering the device off and on.
+Note that the test point diameter and spacing is such that the round style of connectors fit well but the square
+profile connectors do not.
 
 ## GPIO Pinout
 


### PR DESCRIPTION
Added instructions for an alternative method of connecting to the test points  without cutting or soldering by using jumper wires with (round) DuPoint connectors.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
Add an alternative method of connecting to the test points without cutting or soldering by using jumper wires with (round) DuPoint connectors.


## Type of changes

- [ ] New device
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [X] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [X] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [X] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
