### PR TITLE
Update Tasmota to ESPHome migration instructions

### DIFF
--- a/src/docs/devices/Nous-A8T/index.md
+++ b/src/docs/devices/Nous-A8T/index.md
@@ -11,9 +11,9 @@ difficulty: 3
 ## General Notes
 
 This device contains an ESP32 and ships with Tasmota firmware.
-To flash it, follow [this guide to migrate from Tasmota over the air](https://esphome.io/guides/migrate_sonoff_tasmota/)
-and follow the steps for ESP32 devices with Tasmota v12 or higher.
-Alternatively, the device can be disassembled by unscrewing the screw in the hole at the bottom side of the plug.
+To flash it with ESPHome over the air, refer to the [**Migrating from Tasmota**](https://esphome.io/guides/migrate_sonoff_tasmota/)
+guide and follow the steps for ESP32 devices with Tasmota v12 or higher.
+Alternatively, the device can be disassembled by unscrewing the screw in the hole at the bottom side of the plug for serial flashing.
 
 > [!WARNING]
 If you want to avoid having to disassemble your device in the future, make sure the initial ESPHome firmware uploaded

--- a/src/docs/devices/Nous-A8T/index.md
+++ b/src/docs/devices/Nous-A8T/index.md
@@ -11,8 +11,11 @@ difficulty: 3
 ## General Notes
 
 This device contains an ESP32 and ships with Tasmota firmware.
-To flash it, the device can be disassembled by unscrewing the screw in the hole at the bottom side of the plug.
-Alternatively, this procedure by kadam12g works as well—start at step 21: [https://github.com/kadam12g/ESPHome-Shelly-Plus-Plug-S?tab=readme-ov-file](https://github.com/kadam12g/ESPHome-Shelly-Plus-Plug-S?tab=readme-ov-file)
+To flash it, follow [this guide to migrate from Tasmota over the air](https://esphome.io/guides/migrate_sonoff_tasmota/) and follow the steps for ESP32 devices with Tasmota v12 or higher.
+Alternatively, the device can be disassembled by unscrewing the screw in the hole at the bottom side of the plug.
+
+> [!WARNING]
+If you want to avoid having to disassemble your device in the future, make sure the initial ESPHome firmware uploaded to the Tasmota firmware upgrade page has the option `allow_partition_access: true` configured!
 
 ### Example Configuration
 
@@ -58,6 +61,7 @@ api:
 # Allow Over-The-Air updates
 ota:
   - platform: esphome
+    allow_partition_access: true  # Only needed when converting from Tasmota over the air, can be removed after the partition table update
 
 # Allow provisioning Wi-Fi via serial
 improv_serial:

--- a/src/docs/devices/Nous-A8T/index.md
+++ b/src/docs/devices/Nous-A8T/index.md
@@ -13,7 +13,8 @@ difficulty: 3
 This device contains an ESP32 and ships with Tasmota firmware.
 To flash it with ESPHome over the air, refer to the [**Migrating from Tasmota**](https://esphome.io/guides/migrate_sonoff_tasmota/)
 guide and follow the steps for ESP32 devices with Tasmota v12 or higher.
-Alternatively, the device can be disassembled by unscrewing the screw in the hole at the bottom side of the plug for serial flashing.
+Alternatively, the device can be disassembled by unscrewing the screw in
+the hole at the bottom side of the plug for serial flashing.
 
 > [!WARNING]
 If you want to avoid having to disassemble your device in the future, make sure the initial ESPHome firmware uploaded

--- a/src/docs/devices/Nous-A8T/index.md
+++ b/src/docs/devices/Nous-A8T/index.md
@@ -11,11 +11,13 @@ difficulty: 3
 ## General Notes
 
 This device contains an ESP32 and ships with Tasmota firmware.
-To flash it, follow [this guide to migrate from Tasmota over the air](https://esphome.io/guides/migrate_sonoff_tasmota/) and follow the steps for ESP32 devices with Tasmota v12 or higher.
+To flash it, follow [this guide to migrate from Tasmota over the air](https://esphome.io/guides/migrate_sonoff_tasmota/)
+and follow the steps for ESP32 devices with Tasmota v12 or higher.
 Alternatively, the device can be disassembled by unscrewing the screw in the hole at the bottom side of the plug.
 
 > [!WARNING]
-If you want to avoid having to disassemble your device in the future, make sure the initial ESPHome firmware uploaded to the Tasmota firmware upgrade page has the option `allow_partition_access: true` configured!
+If you want to avoid having to disassemble your device in the future, make sure the initial ESPHome firmware uploaded
+to the Tasmota firmware upgrade page has the option `allow_partition_access: true` configured!
 
 ### Example Configuration
 

--- a/src/docs/devices/Nous-B3T/index.md
+++ b/src/docs/devices/Nous-B3T/index.md
@@ -7,11 +7,16 @@ board: esp32
 difficulty: 2
 ---
 
-![NOUS B3T](B3T_mockup.jpg "Nous B3T WiFi Tasmota Switch Module(2 channel with PM) / Curtain module(1 channel) (ESP32)")
+![NOUS B3T](B3T_mockup.jpg "Nous B3T WiFi Tasmota Switch Module (2 channel with PM) / Curtain module (1 channel) (ESP32)")
 
-This device comes pre-installed with Tasmota. To flash it with ESPHome, refer to the
-[**Migrating from Tasmota**](https://esphome.io/guides/migrate_sonoff_tasmota/)guide. Alternatively, you can
-disassemble the device and solder wires to the test pads ([see pinout](#pinout)) for manual flashing.
+This device comes pre-installed with Tasmota.
+To flash it with ESPHome over the air, refer to the [**Migrating from Tasmota**](https://esphome.io/guides/migrate_sonoff_tasmota/)
+guide and follow the steps for ESP32 devices with Tasmota v12 or higher.
+Alternatively, you can disassemble the device and solder wires to the test pads ([see pinout](#pinout)) for manual flashing.
+
+> [!WARNING]
+If you want to avoid having to disassemble your device in the future, make sure the initial ESPHome firmware uploaded
+to the Tasmota firmware upgrade page has the option `allow_partition_access: true` configured!
 
 ## GPIO Pinout
 
@@ -50,6 +55,7 @@ api:
 
 ota:
   - platform: esphome
+    allow_partition_access: true  # Only needed when converting from Tasmota over the air, can be removed after the partition table update
 
 wifi:
   ssid: !secret wifi_ssid
@@ -349,7 +355,6 @@ binary_sensor:
 
 ## Pinout
 
-Because the built-in button is connected to GPIO4, unlike on other devices, you also need to solder a wire to GPIO0 and
-pull it to GND to enter flash mode.
+You need to solder a wire to GPIO0 and connect it to GND to enter flash mode.
 
 ![NOUS B3T Pinout](pinout.png "Nous B3T Pinout")


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

To be merged after the release of 2026.5.0

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
