### PR TITLE
Extend yamllint rules from default

### DIFF
--- a/.github/ISSUE_TEMPLATE/device-config-issue.yml
+++ b/.github/ISSUE_TEMPLATE/device-config-issue.yml
@@ -5,8 +5,10 @@ type: Bug
 body:
   - type: markdown
     attributes:
-      value: |
-        Thank you for reporting an issue with a device configuration! Please provide as much detail as possible to help us resolve the problem.
+      value: >
+        Thank you for reporting an issue with a device configuration!
+        Please provide as much detail as possible to help us resolve the
+        problem.
 
   - type: input
     id: device-name

--- a/.github/ISSUE_TEMPLATE/outdated-config.yml
+++ b/.github/ISSUE_TEMPLATE/outdated-config.yml
@@ -5,8 +5,10 @@ type: Task
 body:
   - type: markdown
     attributes:
-      value: |
-        Thank you for helping keep our device configurations up to date! Use this template to report configurations that need updating due to ESPHome changes, deprecated components, or improved practices.
+      value: >
+        Thank you for helping keep our device configurations up to date!
+        Use this template to report configurations that need updating due to
+        ESPHome changes, deprecated components, or improved practices.
 
   - type: textarea
     id: what-needs-changing

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: markdownlint-cli
-        uses: nosborn/github-action-markdown-cli@508d6cefd8f0cc99eab5d2d4685b1d5f470042c1 # v3.5.0
+        uses: nosborn/github-action-markdown-cli@508d6cefd8f0cc99eab5d2d4685b1d5f470042c1  # v3.5.0
         with:
           config_file: ".markdownlintrc"
           files: src
@@ -46,7 +46,11 @@ jobs:
           files_with_crlf=$(find . -type f \
             -not -path "./.git/*" \
             -not -path "./node_modules/*" \
-            \( -name "*.md" -o -name "*.yml" -o -name "*.yaml" -o -name "*.json" -o -name "*.py" -o -name "*.sh" -o -name "*.js" -o -name "*.ts" \) \
+            \( \
+              -name "*.md" -o -name "*.yml" -o -name "*.yaml" \
+              -o -name "*.json" -o -name "*.py" -o -name "*.sh" \
+              -o -name "*.js" -o -name "*.ts" \
+            \) \
             -exec file {} \; | grep "CRLF" || true)
 
           if [ -n "$files_with_crlf" ]; then

--- a/.github/workflows/made-for-esphome.yml
+++ b/.github/workflows/made-for-esphome.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0 # Ensure we have full history for diff
+          fetch-depth: 0  # Ensure we have full history for diff
 
       - name: Check for made-for-esphome
         id: check-made-for-esphome
@@ -46,7 +46,9 @@ jobs:
             const baseBranch = context.payload.pull_request.base.ref;
 
             // Get the diff for src/docs/devices/**/index.md files
-            const { exitCode, stdout, stderr } = await exec.getExecOutput(`git diff origin/${baseBranch} -- src/docs/devices/**/index.md`);
+            const { exitCode, stdout, stderr } = await exec.getExecOutput(
+              `git diff origin/${baseBranch} -- src/docs/devices/**/index.md`
+            );
 
             // Check if any line contains 'made-for-esphome: true'
             return stdout.includes('+made-for-esphome: true') || stdout.includes('+made-for-esphome: True');
@@ -89,7 +91,8 @@ jobs:
               body: updatedBody
             });
 
-            const message = "This PR has been labeled as **Made for ESPHome** and is pending review. Please complete the checklist added to the description above.";
+            const message = "This PR has been labeled as **Made for ESPHome** and is pending review. " +
+              "Please complete the checklist added to the description above.";
 
             await github.rest.pulls.createReview({
               pull_number: pr.number,

--- a/.yamllintrc
+++ b/.yamllintrc
@@ -2,3 +2,7 @@ extends: default
 
 rules:
   document-start: disable
+  line-length:
+    max: 120
+  truthy:
+    check-keys: false

--- a/.yamllintrc
+++ b/.yamllintrc
@@ -1,1 +1,4 @@
-document-start: disable
+extends: default
+
+rules:
+  document-start: disable


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

The previous `.yamllintrc` had only `document-start: disable` at the top level, which is not a valid yamllint config — it neither extends `default` nor sits under a `rules:` block, so the rule was effectively ignored and no other rules were applied. This PR switches to `extends: default` and tunes a couple of rules to fit the repo:

- `line-length: max: 120` — the default 80 is impractical for prose `description:` strings in issue templates, action URLs in workflows, and shell snippets.
- `truthy: check-keys: false` — accept `on:` as a key in GitHub workflow files.
- `document-start: disable` — preserved from the previous config.

The remaining real violations are fixed in the workflow and issue-template files: the second space before `# vN.N.N` SHA-tag comments, a long `find -name` alternation broken across lines, two long JS strings in the made-for-esphome workflow wrapped, and the two issue-template intro `value: |` blocks switched to folded `value: >` so the prose can wrap (parsed value verified identical).

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->