### PR TITLE
Fix invalid code-block language identifiers in device docs

### DIFF
--- a/src/docs/devices/Aoycocr-X13-Outdoor-Plug-2AKBP-X13/index.md
+++ b/src/docs/devices/Aoycocr-X13-Outdoor-Plug-2AKBP-X13/index.md
@@ -45,7 +45,7 @@ provided the pins
 
 The pins are on alternate sides:
 
-```us
+```txt
 
 1  3  5  7  9  11  13
 2  4  6  8  10 12  14

--- a/src/docs/devices/FEIT-OM100-RGBW-CA-AG/index.md
+++ b/src/docs/devices/FEIT-OM100-RGBW-CA-AG/index.md
@@ -54,7 +54,7 @@ light:
 Here is the c code for the header file. The code is not mine. I just made some modifications for this bulb. This file
 should be named `better_rgbw_output.h` and be saved in the esphome directory
 
-```C#
+```cpp
 /*  A Better RGBW(W) Output
 
     Based on/inspired by user *envy* at https://github.com/esphome/feature-requests/issues/212#issuecomment-498036079

--- a/src/docs/devices/Tongou-TO-Q-SY1-JWT/index.md
+++ b/src/docs/devices/Tongou-TO-Q-SY1-JWT/index.md
@@ -74,7 +74,7 @@ print("EREF: %d" % data['dps']['25'])
 
 Sample results:
 
-```us
+```txt
 UREF: 15968
 IREF: 12418 * 10
 PREF: 3091 / 10
@@ -84,7 +84,7 @@ EREF: 2653
 Alternatively, the values may be stored in flash in the "key value store" Tuya partition, typically at address
 `0x001d5000` (in more recent devices this address changed to `0x001d9000`):
 
-```us
+```txt
 001d5000  60 3e 00 00 82 30 00 00  13 0c 00 00 5d 0a 00 00  |`>...0......]...|
 ```
 


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

A few device docs were using language identifiers that aren't recognised by the syntax highlighter. Replaced ` ```us ` with ` ```txt ` (Aoycocr X13, Tongou TO-Q-SY1-JWT) and ` ```C# ` with ` ```cpp ` (FEIT OM100), since the contents are plain text and C++ respectively.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->