### PR TITLE
Fix weekly link-check JSON parse failure (npm preamble polluting stdout)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,4 +87,4 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: npm run check-links -- --annotations
+        run: npm run --silent check-links -- --annotations

--- a/.github/workflows/weekly-link-check.yml
+++ b/.github/workflows/weekly-link-check.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Run link checker
         run: |
           set +e
-          npm run check-links -- --all --json > results.json
+          # --silent suppresses npm's "> pkg@ver script\n> cmd" preamble so
+          # stdout is purely the script's JSON output.
+          npm run --silent check-links -- --all --json > results.json
           echo "exitcode=$?"
 
       - name: Update tracking issue


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

The weekly link-check workflow added in #1573 failed on its first scheduled run because `npm run check-links -- --all --json > results.json` redirected npm's own preamble (`> devices.esphome.io@3.0.0 check-links\n> tsx scripts/check-links.ts ...`) into `results.json` ahead of the script's JSON output, breaking `JSON.parse` in the next step (`SyntaxError: Unexpected token '>', "> devices."... is not valid JSON`).

Adding `--silent` to both invocations suppresses npm's preamble so stdout starts cleanly with the script's `{...}` JSON.

Run that exposed the bug: https://github.com/esphome/esphome-devices/actions/runs/25531238886/job/74937823076

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->