### PR TITLE
Set minimum permissions on CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   markdown_lint:
     name: Markdown Lint
@@ -68,8 +71,6 @@ jobs:
     name: External Link Check
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/made-for-esphome.yml
+++ b/.github/workflows/made-for-esphome.yml
@@ -3,13 +3,13 @@ name: Check Made for ESPHome
 on:
   pull_request_target:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   pre-check:
     runs-on: ubuntu-latest
     name: Pre-check for made-for-esphome label
+    permissions: {}
     outputs:
       run: ${{ steps.check-label.outputs.result }}
     steps:
@@ -28,6 +28,8 @@ jobs:
     needs:
       - pre-check
     if: ${{ needs.pre-check.outputs.run == 'true' }}
+    permissions:
+      contents: read
     outputs:
       run: ${{ steps.check-made-for-esphome.outputs.result }}
     steps:
@@ -60,6 +62,7 @@ jobs:
       - check
     if: ${{ needs.check.outputs.run == 'true' }}
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Checkout code


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Locks the GitHub Actions tokens down to least privilege.

`ci.yaml` previously had no top-level `permissions` block, so the lint jobs (`markdown_lint`, `yaml_lint`, `line_endings`) inherited whatever the repo default was — potentially read+write. Adding top-level `permissions: contents: read` covers all four jobs uniformly (they only need to checkout); the now-redundant per-job block on `link_check` is removed.

`made-for-esphome.yml` runs on `pull_request_target`, which is security-sensitive. Switched to deny-by-default (`permissions: {}`) at the top level and made each job's needs explicit: `pre-check` `{}` (only reads event payload, no API/checkout), `check` `contents: read` (checkout + local `git diff`), `update-pull-request` `contents: read` + `pull-requests: write` (label + body + review).

`weekly-link-check.yml` was already minimal and is unchanged.

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

- [ ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->