### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/public/js/adding-devices-quickstart.js
+++ b/public/js/adding-devices-quickstart.js
@@ -91,14 +91,18 @@
 
     if (fork && slug) {
       if (pathHint) {
-        pathHint.innerHTML =
-          "File will be created in <code>" +
-          fork.user +
-          "/" +
-          fork.repo +
-          "</code> at <code>src/docs/devices/" +
-          slug +
-          "/index.md</code>";
+        pathHint.textContent = "";
+        pathHint.appendChild(document.createTextNode("File will be created in "));
+
+        var repoCode = document.createElement("code");
+        repoCode.textContent = fork.user + "/" + fork.repo;
+        pathHint.appendChild(repoCode);
+
+        pathHint.appendChild(document.createTextNode(" at "));
+
+        var fileCode = document.createElement("code");
+        fileCode.textContent = "src/docs/devices/" + slug + "/index.md";
+        pathHint.appendChild(fileCode);
       }
       var params = new URLSearchParams({
         filename: slug + "/index.md",


### PR DESCRIPTION
Potential fix for [https://github.com/esphome/esphome-devices/security/code-scanning/5](https://github.com/esphome/esphome-devices/security/code-scanning/5)

General fix: do not place untrusted input into `innerHTML`. Use `textContent` (or explicit DOM node construction) so values are treated as text, not HTML.

Best fix here (without changing behavior): replace the `pathHint.innerHTML = ...` construction with explicit creation of text nodes and `<code>` elements:
- Keep the same visible output formatting.
- Clear existing content with `pathHint.textContent = ""`.
- Append static text via `document.createTextNode(...)`.
- Append dynamic values (`fork.user + "/" + fork.repo`, `slug + ...`) via `code.textContent = ...`.

File/region to change:
- `public/js/adding-devices-quickstart.js`, in `update()` inside `if (fork && slug) { if (pathHint) { ... } }`, replacing lines 94–101 assignment block.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
