### PR TITLE
Skip github.com/octocat placeholder links in link checker

### DIFF
--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -26,7 +26,9 @@
  *
  * Reserved/private/loopback hostnames (RFC 2606, RFC 1918, mDNS .local,
  * link-local, loopback, 0.0.0.0) are skipped - they are unreachable from
- * CI and treated as explicit example/placeholder URLs.
+ * CI and treated as explicit example/placeholder URLs. Links to GitHub's
+ * `octocat` mascot account (github.com/octocat/...) are skipped for the
+ * same reason - they are conventional placeholders, not real resources.
  */
 
 import { readFileSync } from "node:fs";
@@ -59,6 +61,7 @@ const SKIP = new RegExp(
     "|127\\.|10\\.|192\\.168\\." +
     "|172\\.(1[6-9]|2[0-9]|3[01])\\." +
     "|169\\.254\\.|0\\.0\\.0\\.0" +
+    "|github\\.com/octocat(/|$)" +
     ")",
   "i",
 );


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

The CI link checker treats every URL it finds in changed markdown as a real link, including `https://github.com/octocat/esphome-devices` used as the `placeholder=` value of the fork-URL input on the "Adding a device" quickstart page (introduced in #1573). `octocat` is GitHub's canonical example/mascot account and the URL 404s by design, so the check fails on every PR that touches `adding-devices.mdx`.

Extend the existing skip regex (which already excludes RFC 2606 reserved/private/loopback hosts) to also skip `github.com/octocat/*`. Same rationale, conventional placeholder, not a real resource.

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->