### PR TITLE
Make made-for-esphome workflow comment as esphome[bot]

### DIFF
--- a/.github/workflows/made-for-esphome.yml
+++ b/.github/workflows/made-for-esphome.yml
@@ -63,13 +63,26 @@ jobs:
     if: ${{ needs.check.outputs.run == 'true' }}
     permissions:
       contents: read
-      pull-requests: write
     steps:
-      - name: Checkout code
+      - name: Checkout checklist from base
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
+            .github/made-for-esphome-checklist.md
+          sparse-checkout-cone-mode: false
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Update Pull Request
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const pr = context.payload.pull_request;
             await github.rest.issues.addLabels({


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Two changes to `.github/workflows/made-for-esphome.yml`:

- The `update-pull-request` job now generates a token via the ESPHome GitHub App (same `ESPHOME_GITHUB_APP_CLIENT_ID` / `ESPHOME_GITHUB_APP_PRIVATE_KEY` used in the main esphome repo) and passes it to `actions/github-script`. The label add, body update, and review request will now appear as `esphome[bot]` instead of `github-actions[bot]`. Because the app token carries its own permissions, `pull-requests: write` was dropped from the job's `GITHUB_TOKEN` permissions.
- The checklist file is now sparse-checked-out from `github.event.pull_request.base.sha` rather than relying on the implicit checkout. This makes it explicit that the trusted, base-branch copy of the checklist is what gets appended to the PR description, not whatever a PR head might contain.

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->