### PR TITLE
Validate yaml configs in CI and require file= refs on changed pages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,32 @@ jobs:
           else
             echo "✅ All files have correct LF line endings"
           fi
+  yaml_validate:
+    name: YAML Config Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Need history for the new-page diff (PRs only); shallow is fine
+          # for push events but harmless to fetch full depth here.
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Validate referenced yaml configs
+        env:
+          # On pull_request events these populate the "newly-added page"
+          # check that forbids inline yaml on new device pages. Push events
+          # leave them empty, so the inline-yaml rule is skipped there.
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: npm run --silent validate-yaml
   link_check:
     name: External Link Check
     runs-on: ubuntu-latest

--- a/scripts/validate-yaml-configs.ts
+++ b/scripts/validate-yaml-configs.ts
@@ -289,18 +289,19 @@ function walkMarkdown(dir: string, out: string[]): void {
 }
 
 // Resolve the set of markdown files in `devicesRoot` that the current PR
-// adds, modifies, or substantively renames/copies, between BASE_SHA and
-// HEAD_SHA. Returns absolute paths so callers can match against the same
-// form `walkMarkdown` produces. Returns null if the env vars are absent
-// (the no-inline-yaml rule is then skipped — local runs and `push` builds
-// don't have a meaningful diff base).
+// adds, modifies, renames, copies, or changes type for, between BASE_SHA
+// and HEAD_SHA. Returns absolute paths so callers can match against the
+// same form `walkMarkdown` produces. Returns null if the env vars are
+// absent (the no-inline-yaml rule is then skipped — local runs and `push`
+// builds don't have a meaningful diff base).
 //
-// `--name-status -z` (instead of `--diff-filter=AM --name-only`) so we can
-// see git's per-entry status code: a rename-with-edits comes back as `R85`
-// — the AM filter would skip it entirely and let a moved-and-modified
-// inline-yaml page evade the rule. We include A, M, T, any copy, and
-// renames where the similarity index is less than 100 (i.e. there were
-// edits). Pure renames (`R100`) and deletions are ignored.
+// `--name-status -z` (instead of `--diff-filter=… --name-only`) so we can
+// see git's per-entry status code and pull the *new* path on R/C entries.
+// Any entry whose new path lands on a device markdown counts as changed —
+// including pure renames (`R100`). A pure rename is still a file
+// modification from the contributor's perspective, and the new-rules
+// requirement applies. Only `D` (deletion) and `U` (unmerged, shouldn't
+// appear in CI) are ignored.
 function findChangedMarkdown(devicesRoot: string): Set<string> | null {
   const base = process.env.BASE_SHA;
   const head = process.env.HEAD_SHA;
@@ -332,13 +333,11 @@ function findChangedMarkdown(devicesRoot: string): Set<string> | null {
     const code = status[0];
     let candidatePath: string | null = null;
     if (code === "R" || code === "C") {
-      // Format: <Rxx|Cxx>\0<old>\0<new>
-      const newPath = tokens[i + 2];
+      // Format: <Rxx|Cxx>\0<old>\0<new> — take the new path, similarity
+      // index ignored: any rename/copy onto a device markdown must follow
+      // the rules.
+      candidatePath = tokens[i + 2];
       i += 3;
-      // R100 = pure rename, no content change — leave it alone. Copies
-      // (Cxx) are always a new path, so flag them regardless of similarity.
-      if (code === "R" && status === "R100") continue;
-      candidatePath = newPath;
     } else {
       // Format: <code>\0<path>
       const p = tokens[i + 1];

--- a/scripts/validate-yaml-configs.ts
+++ b/scripts/validate-yaml-configs.ts
@@ -15,7 +15,11 @@
  *      defined in their secrets file.
  *
  * Additional rules for the page-level form (markdown with `file=` fences):
- *   4. The first yaml fence on a page must reference `config.yaml`.
+ *   4. The first yaml fence on a page must reference `config.yaml`. Pages
+ *      added or modified in the current PR (detected via BASE_SHA/HEAD_SHA
+ *      env vars) must use `file=`-based fences exclusively — no inline
+ *      yaml. Pages untouched by the PR remain unchecked for inline yaml so
+ *      the in-flight migration of legacy pages isn't blocked.
  *   5. `config.yaml` must be hardware-only:
  *        - No top-level `api:`, `ota:`, `mqtt:`, `web_server:`,
  *          `web_server_idf:`, `improv_serial:`, `captive_portal:`,
@@ -30,6 +34,7 @@
  */
 import * as fs from "fs";
 import * as path from "path";
+import { execFileSync } from "child_process";
 import { fileURLToPath } from "url";
 // js-yaml is a transitive dep of gray-matter; import directly to parse.
 import yaml from "js-yaml";
@@ -119,14 +124,14 @@ function checkSensitiveInTree(
   }
 }
 
-interface FenceRef {
-  fileAttr: string;
+interface YamlFence {
+  fileAttr: string | null; // null when the fence is inline (no `file=` attr)
   lineNumber: number; // 1-indexed source line of the fence opener
 }
 
-function findFenceRefs(md: string): FenceRef[] {
+function findYamlFences(md: string): YamlFence[] {
   const lines = md.split(/\r?\n/);
-  const refs: FenceRef[] = [];
+  const fences: YamlFence[] = [];
   let inFence: { char: string; len: number } | null = null;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -146,11 +151,12 @@ function findFenceRefs(md: string): FenceRef[] {
     inFence = { char: fenceChar, len: fenceLen };
     if (lang !== "yaml" && lang !== "yml") continue;
     const fileMatch = meta.match(/(^|\s)file=(?:"([^"]+)"|'([^']+)'|([^\s"']+))/);
-    if (!fileMatch) continue;
-    const fileAttr = fileMatch[2] ?? fileMatch[3] ?? fileMatch[4] ?? "";
-    refs.push({ fileAttr, lineNumber: i + 1 });
+    const fileAttr = fileMatch
+      ? fileMatch[2] ?? fileMatch[3] ?? fileMatch[4] ?? ""
+      : null;
+    fences.push({ fileAttr, lineNumber: i + 1 });
   }
-  return refs;
+  return fences;
 }
 
 interface Issue {
@@ -282,6 +288,52 @@ function walkMarkdown(dir: string, out: string[]): void {
   }
 }
 
+// Resolve the set of markdown files in `devicesRoot` that the current PR
+// adds or modifies, between BASE_SHA and HEAD_SHA. Returns absolute paths so
+// callers can match against the same form `walkMarkdown` produces. Returns
+// null if the env vars are absent (the no-inline-yaml rule is then skipped —
+// local runs and `push` builds don't have a meaningful diff base).
+function findChangedMarkdown(devicesRoot: string): Set<string> | null {
+  const base = process.env.BASE_SHA;
+  const head = process.env.HEAD_SHA;
+  if (!base || !head) return null;
+  let out: string;
+  try {
+    out = execFileSync(
+      "git",
+      [
+        "diff",
+        "--name-only",
+        // A = added, M = modified. Renames/copies are intentionally excluded:
+        // a pure rename of an inline-yaml page shouldn't force migration.
+        "--diff-filter=AM",
+        `${base}..${head}`,
+        "--",
+        "src/docs/devices",
+      ],
+      { encoding: "utf8" }
+    );
+  } catch (err) {
+    console.error(`git diff failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
+  const changed = new Set<string>();
+  for (const line of out.split("\n")) {
+    const p = line.trim();
+    if (!p) continue;
+    if (!/\.(md|mdx)$/i.test(p)) continue;
+    const abs = path.resolve(process.cwd(), p);
+    // Restrict to the devices tree (the diff filter already does, but be
+    // defensive against future trigger changes).
+    if (!abs.startsWith(devicesRoot + path.sep) && abs !== devicesRoot) continue;
+    changed.add(abs);
+  }
+  return changed;
+}
+
+const ADDING_DEVICES_HELP_URL =
+  "https://devices.esphome.io/devices/adding-devices#configuration-yaml-files";
+
 function main(): void {
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = path.dirname(__filename);
@@ -296,6 +348,12 @@ function main(): void {
 
   const issues: Issue[] = [];
 
+  // Pages added or modified by the current PR (when BASE_SHA/HEAD_SHA are
+  // set) must be on the migrated `file=`-based form — no inline yaml fences
+  // allowed. Pages the PR doesn't touch are mid-migration and remain
+  // unchecked here.
+  const changedMarkdown = findChangedMarkdown(devicesRoot);
+
   // Walk markdown first to collect every yaml file referenced via a `file=`
   // fence. Pre-existing yaml files that no markdown points at (legacy
   // downloadable examples) are intentionally out of scope: this validator
@@ -305,9 +363,30 @@ function main(): void {
 
   const referencedYaml = new Set<string>();
   for (const md of mdFiles) {
-    const refs = findFenceRefs(fs.readFileSync(md, "utf8"));
-    if (refs.length === 0) continue;
+    const fences = findYamlFences(fs.readFileSync(md, "utf8"));
+    if (fences.length === 0) continue;
     const rel = path.relative(process.cwd(), md);
+    const isChangedPage = changedMarkdown?.has(md) ?? false;
+
+    const refs = fences.filter(
+      (f): f is YamlFence & { fileAttr: string } => f.fileAttr !== null
+    );
+
+    if (isChangedPage) {
+      for (const f of fences) {
+        if (f.fileAttr === null) {
+          issues.push({
+            file: rel,
+            line: f.lineNumber,
+            message:
+              "added or modified device pages must use `file=`-based yaml fences — inline yaml is no longer accepted; move the config into a sibling yaml file and reference it. " +
+              `See ${ADDING_DEVICES_HELP_URL}`,
+          });
+        }
+      }
+    }
+
+    if (refs.length === 0) continue;
     if (refs[0].fileAttr.toLowerCase() !== "config.yaml") {
       issues.push({
         file: rel,

--- a/scripts/validate-yaml-configs.ts
+++ b/scripts/validate-yaml-configs.ts
@@ -289,10 +289,18 @@ function walkMarkdown(dir: string, out: string[]): void {
 }
 
 // Resolve the set of markdown files in `devicesRoot` that the current PR
-// adds or modifies, between BASE_SHA and HEAD_SHA. Returns absolute paths so
-// callers can match against the same form `walkMarkdown` produces. Returns
-// null if the env vars are absent (the no-inline-yaml rule is then skipped —
-// local runs and `push` builds don't have a meaningful diff base).
+// adds, modifies, or substantively renames/copies, between BASE_SHA and
+// HEAD_SHA. Returns absolute paths so callers can match against the same
+// form `walkMarkdown` produces. Returns null if the env vars are absent
+// (the no-inline-yaml rule is then skipped — local runs and `push` builds
+// don't have a meaningful diff base).
+//
+// `--name-status -z` (instead of `--diff-filter=AM --name-only`) so we can
+// see git's per-entry status code: a rename-with-edits comes back as `R85`
+// — the AM filter would skip it entirely and let a moved-and-modified
+// inline-yaml page evade the rule. We include A, M, T, any copy, and
+// renames where the similarity index is less than 100 (i.e. there were
+// edits). Pure renames (`R100`) and deletions are ignored.
 function findChangedMarkdown(devicesRoot: string): Set<string> | null {
   const base = process.env.BASE_SHA;
   const head = process.env.HEAD_SHA;
@@ -303,10 +311,8 @@ function findChangedMarkdown(devicesRoot: string): Set<string> | null {
       "git",
       [
         "diff",
-        "--name-only",
-        // A = added, M = modified. Renames/copies are intentionally excluded:
-        // a pure rename of an inline-yaml page shouldn't force migration.
-        "--diff-filter=AM",
+        "--name-status",
+        "-z",
         `${base}..${head}`,
         "--",
         "src/docs/devices",
@@ -318,12 +324,33 @@ function findChangedMarkdown(devicesRoot: string): Set<string> | null {
     process.exit(1);
   }
   const changed = new Set<string>();
-  for (const line of out.split("\n")) {
-    const p = line.trim();
-    if (!p) continue;
-    if (!/\.(md|mdx)$/i.test(p)) continue;
-    const abs = path.resolve(process.cwd(), p);
-    // Restrict to the devices tree (the diff filter already does, but be
+  const tokens = out.split("\0");
+  let i = 0;
+  while (i < tokens.length) {
+    const status = tokens[i];
+    if (!status) { i++; continue; }
+    const code = status[0];
+    let candidatePath: string | null = null;
+    if (code === "R" || code === "C") {
+      // Format: <Rxx|Cxx>\0<old>\0<new>
+      const newPath = tokens[i + 2];
+      i += 3;
+      // R100 = pure rename, no content change — leave it alone. Copies
+      // (Cxx) are always a new path, so flag them regardless of similarity.
+      if (code === "R" && status === "R100") continue;
+      candidatePath = newPath;
+    } else {
+      // Format: <code>\0<path>
+      const p = tokens[i + 1];
+      i += 2;
+      // A = added, M = modified, T = type change. D (deleted) and U
+      // (unmerged — shouldn't appear in CI) are ignored.
+      if (code === "A" || code === "M" || code === "T") candidatePath = p;
+    }
+    if (!candidatePath) continue;
+    if (!/\.(md|mdx)$/i.test(candidatePath)) continue;
+    const abs = path.resolve(process.cwd(), candidatePath);
+    // Restrict to the devices tree (the path-spec already does, but be
     // defensive against future trigger changes).
     if (!abs.startsWith(devicesRoot + path.sep) && abs !== devicesRoot) continue;
     changed.add(abs);


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Adds a `yaml_validate` CI job that runs [`scripts/validate-yaml-configs.ts`](scripts/validate-yaml-configs.ts) on every push and pull request, so the rules the script already encodes (parse-clean YAML, no `!secret`/passwords, hardware-only `config.yaml`) are enforced against `file=`-referenced configs in CI and not just locally.

The validator is also extended with a new check that runs only on pull requests: any device markdown page added or modified in the PR (detected via `BASE_SHA`/`HEAD_SHA` from the `pull_request` event) must use `file=`-based yaml fences exclusively — no inline yaml. Pages the PR doesn't touch are left untouched so the in-flight migration of the ~656 legacy pages isn't blocked. When the rule fires, the error message links contributors at the live [adding-devices#configuration-yaml-files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files) section.

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

- [ ] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [ ] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->