### PR TITLE
Require GitHub url= yaml fence on made-for-esphome pages

### DIFF
--- a/scripts/validate-yaml-configs.ts
+++ b/scripts/validate-yaml-configs.ts
@@ -17,9 +17,17 @@
  * Additional rules for the page-level form (markdown with `file=` fences):
  *   4. The first yaml fence on a page must reference `config.yaml`. Pages
  *      added or modified in the current PR (detected via BASE_SHA/HEAD_SHA
- *      env vars) must use `file=`-based fences exclusively — no inline
- *      yaml. Pages untouched by the PR remain unchecked for inline yaml so
- *      the in-flight migration of legacy pages isn't blocked.
+ *      env vars) must use `file=`- or `url=`-based fences exclusively — no
+ *      inline yaml. Pages untouched by the PR remain unchecked for inline
+ *      yaml so the in-flight migration of legacy pages isn't blocked.
+ *
+ *   6. Pages with `made-for-esphome: true` in frontmatter that are added
+ *      or modified in the current PR must include at least one `url=`
+ *      yaml fence pointing at the manufacturer's config on GitHub
+ *      (`github.com` or `raw.githubusercontent.com`). The Made-for-ESPHome
+ *      programme requires the firmware config to be open and reachable;
+ *      a live link to the upstream yaml is how we surface that on the
+ *      device page.
  *   5. `config.yaml` must be hardware-only:
  *        - No top-level `api:`, `ota:`, `mqtt:`, `web_server:`,
  *          `web_server_idf:`, `improv_serial:`, `captive_portal:`,
@@ -36,8 +44,41 @@ import * as fs from "fs";
 import * as path from "path";
 import { execFileSync } from "child_process";
 import { fileURLToPath } from "url";
+import matter from "gray-matter";
 // js-yaml is a transitive dep of gray-matter; import directly to parse.
 import yaml from "js-yaml";
+
+// Hosts a `url=` yaml fence may point at — kept in sync with the build-time
+// allowlist in src/integrations/remark-yaml-include.ts. A `url=` fence is
+// only counted as "the upstream config is reachable" if its host is one of
+// these; anything else is dropped at render time and shouldn't satisfy the
+// made-for-esphome rule either.
+const URL_HOST_ALLOWLIST = new Set(["github.com", "raw.githubusercontent.com"]);
+
+function isAllowedGitHubUrl(value: string): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === "https:" && URL_HOST_ALLOWLIST.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+// Truthy `made-for-esphome` covers the YAML boolean (`true`/`True` parse to
+// the JS boolean `true`) and the rare string form. Anything else — missing,
+// `false`, `pending` — is treated as not made-for-esphome.
+function isMadeForEsphome(content: string): boolean {
+  let data: Record<string, unknown>;
+  try {
+    data = matter(content).data as Record<string, unknown>;
+  } catch {
+    return false;
+  }
+  const v = data["made-for-esphome"];
+  if (typeof v === "boolean") return v;
+  if (typeof v === "string") return /^true$/i.test(v.trim());
+  return false;
+}
 
 const HARDWARE_ONLY_FORBIDDEN = new Set([
   "api",
@@ -125,7 +166,8 @@ function checkSensitiveInTree(
 }
 
 interface YamlFence {
-  fileAttr: string | null; // null when the fence is inline (no `file=` attr)
+  fileAttr: string | null; // null when the fence has no `file=` attr
+  urlAttr: string | null; // null when the fence has no `url=` attr
   lineNumber: number; // 1-indexed source line of the fence opener
 }
 
@@ -154,7 +196,11 @@ function findYamlFences(md: string): YamlFence[] {
     const fileAttr = fileMatch
       ? fileMatch[2] ?? fileMatch[3] ?? fileMatch[4] ?? ""
       : null;
-    fences.push({ fileAttr, lineNumber: i + 1 });
+    const urlMatch = meta.match(/(^|\s)url=(?:"([^"]+)"|'([^']+)'|([^\s"']+))/);
+    const urlAttr = urlMatch
+      ? urlMatch[2] ?? urlMatch[3] ?? urlMatch[4] ?? ""
+      : null;
+    fences.push({ fileAttr, urlAttr, lineNumber: i + 1 });
   }
   return fences;
 }
@@ -389,10 +435,11 @@ function main(): void {
 
   const referencedYaml = new Set<string>();
   for (const md of mdFiles) {
-    const fences = findYamlFences(fs.readFileSync(md, "utf8"));
-    if (fences.length === 0) continue;
+    const rawMd = fs.readFileSync(md, "utf8");
+    const fences = findYamlFences(rawMd);
     const rel = path.relative(process.cwd(), md);
     const isChangedPage = changedMarkdown?.has(md) ?? false;
+    const madeForEsphome = isMadeForEsphome(rawMd);
 
     const refs = fences.filter(
       (f): f is YamlFence & { fileAttr: string } => f.fileAttr !== null
@@ -400,12 +447,36 @@ function main(): void {
 
     if (isChangedPage) {
       for (const f of fences) {
-        if (f.fileAttr === null) {
+        // A fence is "inline" only when it has neither `file=` nor `url=`.
+        // `url=` blocks pull from the manufacturer's repo at visit time —
+        // they're a valid migrated form for made-for-esphome devices that
+        // don't want their config vendored into this repo.
+        if (f.fileAttr === null && f.urlAttr === null) {
           issues.push({
             file: rel,
             line: f.lineNumber,
             message:
-              "added or modified device pages must use `file=`-based yaml fences — inline yaml is no longer accepted; move the config into a sibling yaml file and reference it. " +
+              "added or modified device pages must use `file=`- or `url=`-based yaml fences — inline yaml is no longer accepted; move the config into a sibling yaml file and reference it. " +
+              `See ${ADDING_DEVICES_HELP_URL}`,
+          });
+        }
+      }
+
+      // Made-for-ESPHome devices certify that their config is open and
+      // available to end users (see .github/made-for-esphome-checklist.md).
+      // The way we surface that on a device page is a `url=` yaml fence
+      // pointing at the manufacturer's repo so the rendered page shows the
+      // current upstream config. Require at least one such fence on every
+      // PR that adds or modifies a made-for-esphome page.
+      if (madeForEsphome) {
+        const hasGitHubUrlFence = fences.some(
+          (f) => f.urlAttr !== null && isAllowedGitHubUrl(f.urlAttr)
+        );
+        if (!hasGitHubUrlFence) {
+          issues.push({
+            file: rel,
+            message:
+              "`made-for-esphome: true` pages must include a yaml fence with `url=` pointing at the manufacturer's config on `github.com` or `raw.githubusercontent.com` — e.g. ```` ```yaml url=https://github.com/<owner>/<repo>/blob/<ref>/<path>.yaml ```` — so the rendered page shows the upstream config live. " +
               `See ${ADDING_DEVICES_HELP_URL}`,
           });
         }

--- a/scripts/validate-yaml-configs.ts
+++ b/scripts/validate-yaml-configs.ts
@@ -14,20 +14,16 @@
  *      Example configs must not depend on entries the user may not have
  *      defined in their secrets file.
  *
- * Additional rules for the page-level form (markdown with `file=` fences):
- *   4. The first yaml fence on a page must reference `config.yaml`. Pages
- *      added or modified in the current PR (detected via BASE_SHA/HEAD_SHA
- *      env vars) must use `file=`- or `url=`-based fences exclusively — no
+ * Additional rules for the page-level form (markdown with `file=`/`url=`
+ * fences):
+ *   4. The first `file=` fence on a page must reference `config.yaml`.
+ *      `url=` fences may appear before or after — the ordering rule only
+ *      counts `file=` fences, since `config.yaml` is the in-repo hardware
+ *      manifest and `url=` is the live upstream link. Pages added or
+ *      modified in the current PR (detected via BASE_SHA/HEAD_SHA env
+ *      vars) must use `file=`- or `url=`-based fences exclusively — no
  *      inline yaml. Pages untouched by the PR remain unchecked for inline
  *      yaml so the in-flight migration of legacy pages isn't blocked.
- *
- *   6. Pages with `made-for-esphome: true` in frontmatter that are added
- *      or modified in the current PR must include at least one `url=`
- *      yaml fence pointing at the manufacturer's config on GitHub
- *      (`github.com` or `raw.githubusercontent.com`). The Made-for-ESPHome
- *      programme requires the firmware config to be open and reachable;
- *      a live link to the upstream yaml is how we surface that on the
- *      device page.
  *   5. `config.yaml` must be hardware-only:
  *        - No top-level `api:`, `ota:`, `mqtt:`, `web_server:`,
  *          `web_server_idf:`, `improv_serial:`, `captive_portal:`,
@@ -39,6 +35,16 @@
  *        - No `platform: homeassistant`, `platform: mqtt`, or
  *          `platform: template` anywhere in the tree — those are
  *          network-dependent or user-derived, not hardware.
+ *   6. Pages with `made-for-esphome: true` in frontmatter that are added
+ *      or modified in the current PR must include at least one `url=`
+ *      yaml fence pointing at a yaml file on the manufacturer's GitHub
+ *      repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.y[a]ml`
+ *      or `raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>.y[a]ml`).
+ *      The Made-for-ESPHome programme requires the firmware config to be
+ *      open and reachable; a live link to the upstream yaml is how we
+ *      surface that on the device page. `url=` is also permitted on
+ *      non-made-for-esphome pages (e.g. to mirror an upstream config) but
+ *      isn't the standard form there — `file=config.yaml` is.
  */
 import * as fs from "fs";
 import * as path from "path";
@@ -50,18 +56,54 @@ import yaml from "js-yaml";
 
 // Hosts a `url=` yaml fence may point at — kept in sync with the build-time
 // allowlist in src/integrations/remark-yaml-include.ts. A `url=` fence is
-// only counted as "the upstream config is reachable" if its host is one of
-// these; anything else is dropped at render time and shouldn't satisfy the
-// made-for-esphome rule either.
+// only counted as "the upstream config is reachable" if its host is one
+// of these AND the path resolves to a yaml file the renderer can actually
+// fetch as raw bytes; anything else is dropped at render time and
+// shouldn't satisfy the made-for-esphome rule either.
 const URL_HOST_ALLOWLIST = new Set(["github.com", "raw.githubusercontent.com"]);
+const YAML_EXT = /\.ya?ml$/i;
 
+// Recognise the exact URL shapes that `remark-yaml-include` knows how to
+// normalise to a raw yaml fetch. Anything else (e.g. a repo root, a
+// directory listing, an HTML page) would render as HTML or 404 in the
+// browser — those mustn't satisfy the made-for-esphome rule.
+//
+//   raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>.y[a]ml
+//   raw.githubusercontent.com/<owner>/<repo>/refs/(heads|tags)/<ref>/<path>.y[a]ml
+//   github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.y[a]ml
+//   github.com/<owner>/<repo>/(blob|raw)/refs/(heads|tags)/<ref>/<path>.y[a]ml
 function isAllowedGitHubUrl(value: string): boolean {
+  let u: URL;
   try {
-    const u = new URL(value);
-    return u.protocol === "https:" && URL_HOST_ALLOWLIST.has(u.hostname);
+    u = new URL(value);
   } catch {
     return false;
   }
+  if (u.protocol !== "https:") return false;
+  if (!URL_HOST_ALLOWLIST.has(u.hostname)) return false;
+
+  const segments = u.pathname.replace(/^\/+|\/+$/g, "").split("/");
+
+  let pathStart: number;
+  if (u.hostname === "raw.githubusercontent.com") {
+    // owner/repo/ref/path…  OR  owner/repo/refs/(heads|tags)/ref/path…
+    if (segments.length < 4) return false;
+    pathStart =
+      segments[2] === "refs" && (segments[3] === "heads" || segments[3] === "tags")
+        ? 5
+        : 3;
+  } else {
+    // github.com — must be /blob/ or /raw/
+    if (segments.length < 5) return false;
+    if (segments[2] !== "blob" && segments[2] !== "raw") return false;
+    pathStart =
+      segments[3] === "refs" && (segments[4] === "heads" || segments[4] === "tags")
+        ? 6
+        : 4;
+  }
+  if (segments.length <= pathStart) return false; // no path past the ref
+  const lastSeg = segments[segments.length - 1];
+  return YAML_EXT.test(lastSeg);
 }
 
 // Truthy `made-for-esphome` covers the YAML boolean (`true`/`True` parse to
@@ -476,7 +518,7 @@ function main(): void {
           issues.push({
             file: rel,
             message:
-              "`made-for-esphome: true` pages must include a yaml fence with `url=` pointing at the manufacturer's config on `github.com` or `raw.githubusercontent.com` — e.g. ```` ```yaml url=https://github.com/<owner>/<repo>/blob/<ref>/<path>.yaml ```` — so the rendered page shows the upstream config live. " +
+              "`made-for-esphome: true` pages must include a yaml fence with `url=` pointing at a `.yaml` file in the manufacturer's GitHub repo — e.g. ```` ```yaml url=https://github.com/<owner>/<repo>/blob/<ref>/<path>.yaml ```` (or the `raw.githubusercontent.com` equivalent) — so the rendered page shows the upstream config live. " +
               `See ${ADDING_DEVICES_HELP_URL}`,
           });
         }

--- a/scripts/validate-yaml-configs.ts
+++ b/scripts/validate-yaml-configs.ts
@@ -364,13 +364,23 @@ function checkYamlFile(absPath: string, isHardwareOnly: boolean): Issue[] {
   return issues;
 }
 
-function walkMarkdown(dir: string, out: string[]): void {
+// Walk subdirectories of devicesRoot only. Top-level files like
+// `adding-devices.mdx` and `tuya-convert.md` are docs about the devices
+// tree, not device pages — they contain illustrative yaml examples
+// (inline frontmatter, `url=` demos) that aren't bound by the
+// per-device rules. Real device pages always live one level deeper at
+// `src/docs/devices/<Device>/index.md`.
+function walkMarkdown(dir: string, out: string[], depth = 0): void {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const p = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
-      walkMarkdown(p, out);
-    } else if (entry.isFile() && /\.(md|mdx)$/i.test(entry.name)) {
+      walkMarkdown(p, out, depth + 1);
+    } else if (
+      entry.isFile() &&
+      depth > 0 &&
+      /\.(md|mdx)$/i.test(entry.name)
+    ) {
       out.push(p);
     }
   }

--- a/src/docs/devices/adding-devices.mdx
+++ b/src/docs/devices/adding-devices.mdx
@@ -228,11 +228,11 @@ The following rules are enforced by `npm run validate-devices`:
 | Every yaml file             | Must parse as valid YAML.                                                                     |
 | Every yaml file             | No passwords (literal **or** `!secret`) on any `password:`, `*_password:`, or `psk:` key.     |
 | Every yaml file             | No `!secret` references anywhere. Example configs must not depend on the user's secrets.yaml. |
-| First fence on a page       | Must reference `config.yaml`, and `config.yaml` must appear first on the rendered page.       |
+| First `file=` fence on a page | Must reference `config.yaml`. `url=` fences may appear before or after — only `file=` fences count toward this ordering rule. |
 | `config.yaml` only          | No top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `improv_serial:`, `bluetooth_proxy:`, etc. |
 | `config.yaml` only          | `wifi:` is allowed for radio/hardware tunables (`country`, `power_save_mode`, `output_power`, …). It must not contain `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed (and recommended) so the device boots into a default fallback hotspot. |
 | `config.yaml` only          | No `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere — those are network-dependent or user-derived, not hardware. |
-| `made-for-esphome: true` pages added/modified by the PR | Must include at least one `url=` yaml fence pointing at the manufacturer's config on `github.com` or `raw.githubusercontent.com` — see [Live yaml from a GitHub URL](#live-yaml-from-a-github-url-url-form) below. |
+| `made-for-esphome: true` pages added/modified by the PR | Must include at least one `url=` yaml fence pointing at a `.yaml`/`.yml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob\|raw)/<ref>/...` or `raw.githubusercontent.com/<owner>/<repo>/<ref>/...`) — see [Live yaml from a GitHub URL](#live-yaml-from-a-github-url-url-form) below. |
 
 Additional yaml files (e.g. `voice-assistant.yaml`, `battery-percentage.yaml`) can hold derived sensors,
 automations, or anything else specific to one feature — they just have to be valid YAML and follow the
@@ -246,7 +246,10 @@ parse).
 ### Live yaml from a GitHub URL (`url=` form)
 
 For made-for-ESPHome devices whose configuration lives in the manufacturer's own GitHub repository, you can point
-at the upstream yaml directly instead of vendoring a copy:
+at the upstream yaml directly instead of vendoring a copy. `url=` is allowed on any device page, but it isn't the
+standard form outside of made-for-ESPHome — for ordinary devices, prefer `file=config.yaml` and only fall back to
+`url=` for upstream-pinned references. When a page mixes both, the first `file=` fence must still be
+`config.yaml`; `url=` fences can appear anywhere on the page.
 
 ````md
 ```yaml url=https://github.com/esphome/firmware/blob/main/esp-web-tools/esp32.yaml
@@ -265,6 +268,15 @@ time and renders it inside the same Expressive Code container as a `file=` block
 
 The host is allowlisted at build time: only `https://github.com/...` and `https://raw.githubusercontent.com/...`
 URLs are accepted. Any other host (or non-`https://` URL) triggers a build warning and the block is dropped.
+
+To satisfy the made-for-esphome rule, the URL must also point at an actual yaml file the renderer can fetch as
+raw bytes:
+
+- `https://github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml`
+- `https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>.yaml`
+
+(`.yml` works too; `refs/heads/<branch>` and `refs/tags/<tag>` are both accepted in the ref slot.) A bare repo
+URL, a tree/directory URL, or a non-yaml file all render as HTML or 404 in the browser, so they don't count.
 
 `url=` blocks **are not validated** by `npm run validate-yaml`. Validation only inspects the yaml referenced via
 `file=` because we can only check what's in the repo — the upstream file's contents are out of our control. If you

--- a/src/docs/devices/adding-devices.mdx
+++ b/src/docs/devices/adding-devices.mdx
@@ -232,6 +232,7 @@ The following rules are enforced by `npm run validate-devices`:
 | `config.yaml` only          | No top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `improv_serial:`, `bluetooth_proxy:`, etc. |
 | `config.yaml` only          | `wifi:` is allowed for radio/hardware tunables (`country`, `power_save_mode`, `output_power`, …). It must not contain `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed (and recommended) so the device boots into a default fallback hotspot. |
 | `config.yaml` only          | No `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere — those are network-dependent or user-derived, not hardware. |
+| `made-for-esphome: true` pages added/modified by the PR | Must include at least one `url=` yaml fence pointing at the manufacturer's config on `github.com` or `raw.githubusercontent.com` — see [Live yaml from a GitHub URL](#live-yaml-from-a-github-url-url-form) below. |
 
 Additional yaml files (e.g. `voice-assistant.yaml`, `battery-percentage.yaml`) can hold derived sensors,
 automations, or anything else specific to one feature — they just have to be valid YAML and follow the
@@ -269,6 +270,12 @@ URLs are accepted. Any other host (or non-`https://` URL) triggers a build warni
 `file=` because we can only check what's in the repo — the upstream file's contents are out of our control. If you
 want the same compile-time guarantees, vendor a snapshot into the repo as `config.yaml` (`file=` form) instead, or
 pin the URL to a specific commit SHA so the rendered page can't drift after the device ships.
+
+Pages that opt into [Made for ESPHome](https://devices.esphome.io/made-for-esphome) by setting
+`made-for-esphome: true` in frontmatter **must** include at least one `url=` fence pointing at a host on the
+allowlist. The programme requires the firmware config to be open and reachable; a live link to the upstream yaml
+is how we surface that on the device page. `npm run validate-yaml` enforces this on every PR that adds or modifies
+a made-for-esphome page.
 
 ## Images
 


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Extend the `validate-yaml-configs.ts` CI check so any PR that adds or modifies a device page with `made-for-esphome: true` in frontmatter must include at least one yaml fence with `url=` pointing at the manufacturer's config on `github.com` or `raw.githubusercontent.com`. The Made-for-ESPHome programme requires the firmware config to be open and reachable; the `url=` fence renders the upstream yaml live on the device page, which is how we surface that requirement.

The fence parser also now recognises `url=` as a valid migrated form (alongside `file=`). Previously the "no inline yaml on changed pages" rule incorrectly flagged the SmartHomeShop `url=` fence as inline. That false positive is fixed as a side effect.

Docs in `adding-devices.mdx` updated with a new row in the rules table and a paragraph under the `url=` section explaining the requirement.

Note: 45 of the 46 existing made-for-esphome pages don't have a `url=` fence yet. A future PR that modifies any of those pages will need to add one — the new rule is intentionally a forcing function to backfill the upstream links over time.

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->