### PR TITLE
Fix 404 PCB image links on SiloCityLabs Dikale Filament Dryer

### DIFF
--- a/src/docs/devices/SiloCityLabs-Dikale-Filament-Dryer/index.md
+++ b/src/docs/devices/SiloCityLabs-Dikale-Filament-Dryer/index.md
@@ -42,6 +42,6 @@ The latest state of the configuration is
 
 ## Pictures
 
-![Picture of ESP32 PCB Front](https://shop.silocitylabs.com/cdn/shop/files/dikale-esp32-pcb-front.jpg "Picture of ESP32 PCB Front")
-![Picture of ESP32 PCB Back](https://shop.silocitylabs.com/cdn/shop/files/dikale-esp32-pcb-back.jpg "Picture of ESP32 PCB Back")
+![Picture of ESP32 PCB Front](https://shop.silocitylabs.com/cdn/shop/files/dikale-esp32-pcb-front.webp "Picture of ESP32 PCB Front")
+![Picture of ESP32 PCB Back](https://shop.silocitylabs.com/cdn/shop/files/dikale-esp32-pcb-back.webp "Picture of ESP32 PCB Back")
 ![Picture of OEM Dikale Unit](https://shop.silocitylabs.com/cdn/shop/files/compatible-dikale-unit.jpg "Picture of OEM Dikale Unit")


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

The two PCB photos linked from the SiloCityLabs Dikale Filament Dryer page now 404 — SiloCityLabs swapped them on the Shopify CDN from \`.jpg\` to \`.webp\`. This updates the two URLs to the new extension; both return 200 again. The third image on the page (\`compatible-dikale-unit.jpg\`) is still served as \`.jpg\` and is unchanged.

Found while running the link checker against the changed-pages set in #1594.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are \`!secret wifi_ssid\` and \`!secret wifi_password\`.
- [x] The \`wifi\` or \`ethernet\` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->