### PR TITLE
Update AXA Remote PCB link to new repo location

### DIFF
--- a/src/docs/devices/AXA-Remote/index.md
+++ b/src/docs/devices/AXA-Remote/index.md
@@ -38,4 +38,4 @@ portal to easily setup your local Wi-Fi network credentials.
 
 Additionally a Light-Dependent Resistor (LDR) can be installed to add a light sensor to the board.
 
-[Read more about the PCB](https://github.com/rrooggiieerr/esphome-axaremote/blob/master/PCB.md)
+[Read more about the PCB](https://github.com/rrooggiieerr/esphome-axaremote/blob/main/PCB/README.md)


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

The upstream `rrooggiieerr/esphome-axaremote` repo renamed its default branch from `master` to `main` and moved the PCB documentation from `PCB.md` to `PCB/README.md`. Updates the link on the AXA Remote device page accordingly.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->