### PR TITLE
docs(shelly-1-gen4): document GPIO15 status LED on hardware revision v0.1.2

### DIFF
--- a/src/docs/devices/Shelly-1-Gen4/index.md
+++ b/src/docs/devices/Shelly-1-Gen4/index.md
@@ -100,6 +100,10 @@ binary_sensor:
       then:
         - switch.toggle: relay_1
 
+# Note: GPIO0 reported for some hardware revisions. On revision v0.1.2
+# (printed on the PCB) the status LED is on GPIO15. If GPIO0 does not
+# produce LED activity, try GPIO15 instead.
+
 status_led:
   pin:
     number: 0


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

On Shelly 1 Gen4 hardware revision v0.1.2 (printed on the PCB), the status LED is on GPIO15, not GPIO0 as previously documented. GPIO0 produces no LED activity on this revision.

Found through systematic GPIO sweep testing after ruling out polarity, BSP conflicts, and LP IO MUX state. Other hardware revisions remain untested — leaving the GPIO0 reference in place and adding GPIO15 as the verified alternative for this revision.

Reference: discovered while developing https://github.com/automatous-io/shelly-1-gen4-matter-thread


## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
