### PR TITLE
Fix broken tuya-convert video guide link

### DIFF
--- a/src/docs/devices/tuya-convert.md
+++ b/src/docs/devices/tuya-convert.md
@@ -21,7 +21,7 @@ This page is not a guide to installing and using tuya-convert in general; if you
 the following helpful:
 
 - The [tuya-convert documentation](https://github.com/ct-Open-Source/tuya-convert#requirements); or
-- A [video guide to using tuya-convert on a Raspberry Pi](https://www.digiblur.com/2019/11/tuya-convert-2-flash-tuya-smartlife.html)
+- A [video guide to using tuya-convert on a Raspberry Pi](https://web.archive.org/web/20220523141738/https://www.digiblur.com/2019/11/tuya-convert-2-flash-tuya-smartlife.html)
 
 During the process, don't get nervous - keep calm and be patient.
 


### PR DESCRIPTION
## Summary
- replaces the stale digiblur tuya-convert Raspberry Pi guide URL with an archived copy of the same article
- keeps the existing documentation wording and scope unchanged

## Verification
- `git diff --check -- src/docs/devices/tuya-convert.md`
- confirmed `https://www.digiblur.com/2019/11/tuya-convert-2-flash-tuya-smartlife.html` returns HTTP 404
- confirmed `https://web.archive.org/web/20220523141738/https://www.digiblur.com/2019/11/tuya-convert-2-flash-tuya-smartlife.html` returns HTTP 200
- duplicate PR check found 0 open PRs for `tuya-convert digiblur`, `1576 tuya-convert`, or `web.archive.org tuya-convert` in `esphome/esphome-devices` at preparation time
