### PR TITLE
Update PR template to match enforced page-content rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,10 +15,29 @@
 
 ## Checklist:
 
-- [ ] There are no passwords or secrets references in any examples. 
-      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
-- [ ] The `wifi` or `ethernet` block has no static / manual ip address specified.
-- [ ] The first configuration provided should be **hardware definitions only**.
-      A more involved example can be provided in a separate configuration block.
+The rules below are enforced in CI by `npm run validate-devices` and
+`npm run validate-yaml`. The full reference is at
+[Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).
+
+- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is
+      pulled into the page with a fenced block of the form
+      `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
+- [ ] The first `file=` fence on the page references `config.yaml`.
+- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`,
+      `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`,
+      `bluetooth_proxy:`, or `dashboard_import:`, and no
+      `platform: homeassistant`, `platform: mqtt`, or `platform: template`
+      anywhere in the tree.
+- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables
+      (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`,
+      `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is
+      allowed.
+- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or
+      `psk:` keys, and no `!secret` references anywhere in any example yaml.
+- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one
+      `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's
+      GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or
+      the `raw.githubusercontent.com` equivalent) so the rendered page shows
+      the upstream config live.
 
 <!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

The previous checklist still listed `!secret wifi_ssid`/`!secret wifi_password` as allowed exceptions and only mentioned the wifi static-IP rule. The validators in `scripts/validate-yaml-configs.ts` now enforce a wider set, so rewrite the checklist to mirror them: `file=`/`url=` fence form required, `config.yaml` hardware-only with explicit forbidden top-level keys and platforms, the full `wifi:` allow/forbid list, no `!secret` anywhere, and a `url=` fence on `made-for-esphome` pages. Linked the canonical docs and named the npm scripts so contributors can run them locally.

This was called out in https://github.com/esphome/esphome-devices/pull/1586#issuecomment-4418193735

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and
`npm run validate-yaml`. The full reference is at
[Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is
      pulled into the page with a fenced block of the form
      `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`,
      `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`,
      `bluetooth_proxy:`, or `dashboard_import:`, and no
      `platform: homeassistant`, `platform: mqtt`, or `platform: template`
      anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables
      (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`,
      `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is
      allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or
      `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [x] For pages with `made-for-esphome: true` in frontmatter: at least one
      `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's
      GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or
      the `raw.githubusercontent.com` equivalent) so the rendered page shows
      the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->