### PR TITLE
Remove unused device_ip substitution

### DIFF
--- a/src/docs/devices/Kogan-Smarterhome-Smart-Plug-Energy-Meter-5v-24a-Usb-Ports/config.yaml
+++ b/src/docs/devices/Kogan-Smarterhome-Smart-Plug-Energy-Meter-5v-24a-Usb-Ports/config.yaml
@@ -1,0 +1,74 @@
+substitutions:
+  device_name: kogan_plug_1
+  device_icon: mdi:power-socket-au
+  device_restore: ALWAYS_ON
+
+  # Higher value gives lower watt readout
+  current_res: "0.00225"
+  # Lower value gives lower voltage readout
+  voltage_div: "805"
+
+esphome:
+  name: ${device_name}
+
+esp8266:
+  board: esp8285
+
+logger:
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: 03
+      mode: INPUT_PULLUP
+      inverted: true
+    name: "${device_name}_button"
+    on_press:
+      - switch.toggle: relay
+
+  - platform: status
+    name: "${device_name}_status"
+
+switch:
+  - platform: gpio
+    id: led
+    pin:
+      number: GPIO13
+      inverted: true
+
+  - platform: gpio
+    name: "${device_name}_plug"
+    pin: GPIO14
+    id: relay
+    icon: ${device_icon}
+    restore_mode: ${device_restore}
+    on_turn_on:
+      - switch.turn_on: led
+    on_turn_off:
+      - switch.turn_off: led
+
+sensor:
+  - platform: hlw8012
+    sel_pin:
+      number: GPIO12
+      inverted: true
+    cf_pin: GPIO04
+    cf1_pin: GPIO05
+    current:
+      name: "${device_name}_current"
+      unit_of_measurement: A
+    voltage:
+      name: "${device_name}_voltage"
+      unit_of_measurement: V
+    power:
+      id: ${device_name}_wattage
+      name: "${device_name}_wattage"
+      unit_of_measurement: W
+    energy:
+      id: ${device_name}_energy
+      name: "${device_name}_energy"
+      unit_of_measurement: Wh
+    current_resistor: ${current_res}
+    voltage_divider: ${voltage_div}
+    change_mode_every: 8
+    update_interval: 15s

--- a/src/docs/devices/Kogan-Smarterhome-Smart-Plug-Energy-Meter-5v-24a-Usb-Ports/index.md
+++ b/src/docs/devices/Kogan-Smarterhome-Smart-Plug-Energy-Meter-5v-24a-Usb-Ports/index.md
@@ -23,135 +23,7 @@ board: esp8266
 
 ## Basic Config
 
-```yaml
-substitutions:
-  device_name: kogan_plug_1
-  device_ip: 192.168.x.x
-  device_icon: mdi:power-socket-au
-  device_restore: ALWAYS_ON
-  
-  # Higher value gives lower watt readout
-  current_res: "0.00225"
-  # Lower value gives lower voltage readout
-  voltage_div: "805"
-
-esphome:
-  name: ${device_name}
-
-esp8266:
-  board: esp8285
-
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-
-logger:
-  
-api:
-  reboot_timeout: 15min
-  encryption:
-    key: !secret encryption_key
-
-ota:
-  password: !secret ota_password
-
-binary_sensor:
-  - platform: gpio
-    pin:
-      number: 03
-      mode: INPUT_PULLUP
-      inverted: true
-    name: "${device_name}_button"
-    on_press:
-      - switch.toggle: relay
-
-  - platform: status
-    name: "${device_name}_status"
-
-switch:
-  - platform: gpio
-    id: led
-    pin:
-      number: GPIO13
-      inverted: true
-
-  - platform: gpio
-    name: "${device_name}_plug"
-    pin: GPIO14
-    id: relay
-    icon: ${device_icon}
-    restore_mode: ${device_restore}
-    on_turn_on:
-      - switch.turn_on: led
-    on_turn_off:
-      - switch.turn_off: led
-
-sensor:
-  - platform: hlw8012
-    sel_pin:
-      number: GPIO12
-      inverted: true
-    cf_pin: GPIO04
-    cf1_pin: GPIO05
-    current:
-      name: "${device_name}_current"
-      unit_of_measurement: A
-    voltage:
-      name: "${device_name}_voltage"
-      unit_of_measurement: V
-    power:
-      id: ${device_name}_wattage
-      name: "${device_name}_wattage"
-      unit_of_measurement: W
-    current_resistor: ${current_res}
-    voltage_divider: ${voltage_div}
-    change_mode_every: 8
-    update_interval: 15s
-
-  - platform: total_daily_energy
-    name: "${device_name}_daily_energy"
-    power_id: ${device_name}_wattage
-    filters:
-      - multiply: 0.001
-    unit_of_measurement: kWh
-
-  - platform: wifi_signal
-    name: "${device_name}_rssi"
-    update_interval: 5min
-
-  - platform: uptime
-    id: uptime_sensor
-    name: "${device_name}_uptime"
-    update_interval: 5min
-    on_raw_value:
-      then:
-        - text_sensor.template.publish:
-            id: uptime_human
-            state: !lambda |-
-              int seconds = round(id(uptime_sensor).raw_state);
-              int days = seconds / (24 * 3600);
-              seconds = seconds % (24 * 3600);
-              int hours = seconds / 3600;
-              seconds = seconds % 3600;
-              int minutes = seconds /  60;
-              seconds = seconds % 60;
-              return (
-                (days ? to_string(days) + "d " : "") +
-                (hours ? to_string(hours) + "h " : "") +
-                (minutes ? to_string(minutes) + "m " : "") +
-                (to_string(seconds) + "s")
-              ).c_str();
-
-text_sensor:
-  - platform: template
-    name: "${device_name}_uptime_human"
-    id: uptime_human
-    entity_category: diagnostic
-    icon: mdi:clock-start
-
-time:
-  - platform: homeassistant
-    id: homeassistant_time
+```yaml file=config.yaml
 ```
 
 ## Appendix
@@ -160,17 +32,13 @@ If you are seeing incorrect power/current readings at higher power draws (i.e. c
 ~2000W), your unit most likely has a `BL0937` chip. You can verify this by looking at underside of the PCB, in the
 general area of the ESP chip. To get correct sensor results, make the following config changes:
 
-```yaml
-(...)
+```yaml inline
 substitutions:
   current_res: "0.001" # visually verified the shunt resistor is 1m0
   voltage_div: "1720" # rough value, tested against multimeter readout
-(...)
 sensor:
   - platform: hlw8012
-    (...)
     model: BL0937
-(...)
 ```
 
 The readings should be correct from now on.


### PR DESCRIPTION
# Brief description of the changes

`device_ip` was unused in the body of the config. So it was just confusing to have it.

It would have previously been used for something like https://esphome.io/components/wifi/#manual-ips

```
  manual_ip:
    # Set this to the IP of the ESP
    static_ip: 10.0.0.42
    # Set this to the IP address of the router. Often ends with .1
    gateway: 10.0.0.1
    # The subnet of the network. 255.255.255.0 works for most home networks.
    subnet: 255.255.255.0
```

But it's not any more.

First, I had to migrate to file-based yaml. There's some not-quite-yaml, more like a diff at the end of the file. I decided to put that in a text block instead of extracting it to its own yaml file for validation; it seems like it'd be a shame to have two yaml files mostly duplicates.

Some of the yaml config was forbidden in config.yaml so I moved it into uptime.yaml. I'd be OK to delete this too if reviewer prefers that this page just be about the device, rather than layering uptime monitoring on top.

And all the `!secret` stuff was forbidden so I deleted those sections.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

All the checklist is irrelevant to this change.