### PR TITLE
Update repo references for devices.esphome.io rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/device-config-issue.yml
+++ b/.github/ISSUE_TEMPLATE/device-config-issue.yml
@@ -23,7 +23,7 @@ body:
     id: device-url
     attributes:
       label: Device Page URL
-      description: Please provide the URL to the device page on esphome-devices.com
+      description: Please provide the URL to the device page on devices.esphome.io
       placeholder: https://devices.esphome.io/devices/...
     validations:
       required: true

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -40,7 +40,7 @@ export default defineConfig({
         {
           icon: "github",
           label: "GitHub",
-          href: "https://github.com/esphome/esphome-devices",
+          href: "https://github.com/esphome/devices.esphome.io",
         },
         {
           icon: "discord",
@@ -49,7 +49,7 @@ export default defineConfig({
         },
       ],
       editLink: {
-        baseUrl: "https://github.com/esphome/esphome-devices/edit/main/",
+        baseUrl: "https://github.com/esphome/devices.esphome.io/edit/main/",
       },
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",

--- a/public/js/adding-devices-quickstart.js
+++ b/public/js/adding-devices-quickstart.js
@@ -3,7 +3,7 @@
 (function () {
   "use strict";
 
-  var DEFAULT_REPO = "esphome-devices";
+  var DEFAULT_REPO = "devices.esphome.io";
 
   function slugify(value) {
     return value
@@ -19,7 +19,7 @@
   //   octocat
   //   octocat/my-fork
   //   github.com/octocat
-  //   https://github.com/octocat/esphome-devices
+  //   https://github.com/octocat/devices.esphome.io
   //   https://github.com/octocat/my-fork.git
   // Returns { user, repo } where repo falls back to DEFAULT_REPO when not
   // specified in the input.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -19,7 +19,7 @@ const footerLinks = [
     name: "Community",
     children: [
       { name: "Discord", url: "https://discord.gg/KhAMKrd" },
-      { name: "GitHub", url: "https://github.com/esphome/esphome-devices" },
+      { name: "GitHub", url: "https://github.com/esphome/devices.esphome.io" },
       {
         name: "Forum",
         url: "https://community.home-assistant.io/c/esphome/",

--- a/src/docs/devices/Martin-Jerry-RP-FC01/index.md
+++ b/src/docs/devices/Martin-Jerry-RP-FC01/index.md
@@ -5,7 +5,6 @@ type: misc
 standard: us
 board: esp32
 difficulty: 3
-project-url: https://github.com/esphome/esphome-devices
 ---
 
 *Contributed by [Tim Irvin](https://github.com/irvintim)*
@@ -38,15 +37,15 @@ This integration provides full speed and mode control via ESPHome while preservi
 ## CN2 Pinout (Confirmed)
 
 | CN2 Pin | ESP32-C3 Pin | Function                                     |
-|----------|---------------|----------------------------------------------|
-| 1 | GPIO2 | Status LED / indicator (unused for flashing) |
-| 2 | EN | Reset / Enable                               |
-| 3 | GPIO9 | Boot select                                  |
-| 4 | GPIO8 | Pin (unused for flashing)                    |
-| 5 | 3.3V | Power                                        |
-| 6 | GND | Ground                                       |
-| 7 | GPIO21 | UART RX (to TX of USB-TTL)                   |
-| 8 | GPIO22 | UART TX (to RX of USB-TTL)                   |
+| ------- | ------------ | -------------------------------------------- |
+| 1       | GPIO2        | Status LED / indicator (unused for flashing) |
+| 2       | EN           | Reset / Enable                               |
+| 3       | GPIO9        | Boot select                                  |
+| 4       | GPIO8        | Pin (unused for flashing)                    |
+| 5       | 3.3V         | Power                                        |
+| 6       | GND          | Ground                                       |
+| 7       | GPIO21       | UART RX (to TX of USB-TTL)                   |
+| 8       | GPIO22       | UART TX (to RX of USB-TTL)                   |
 
 ---
 
@@ -70,11 +69,11 @@ When flashing the ESP32-C3 directly, use the following steps to enter boot mode:
 ## Flashing Connections
 
 | USB-TTL Adapter | CN2 Pin | Notes             |
-|------------------|----------|-------------------|
-| TX → | GPIO21 | RX on CN2 (UART0) |
-| RX ← | GPIO22 | TX on CN2 (UART0) |
-| GND | GND | Common ground     |
-| 3.3V | 3.3V | Power supply      |
+| --------------- | ------- | ----------------- |
+| TX →            | GPIO21  | RX on CN2 (UART0) |
+| RX ←            | GPIO22  | TX on CN2 (UART0) |
+| GND             | GND     | Common ground     |
+| 3.3V            | 3.3V    | Power supply      |
 
 ---
 

--- a/src/docs/devices/Shelly-Plug-US/index.md
+++ b/src/docs/devices/Shelly-Plug-US/index.md
@@ -40,7 +40,7 @@ Credit and thanks to the following resources:
 - [FCC documentation][shelly-plug-us-fcc] including pictures of the circuits
 
 [shelly-plug-us-blakadder]: https://templates.blakadder.com/shelly_plug_US.html
-[shelly-plug-s-devices]: https://github.com/esphome/esphome-devices/blob/main/src/docs/devices/Shelly-Plug-S/index.md
+[shelly-plug-s-devices]: https://devices.esphome.io/devices/Shelly-Plug-S/
 [shelly-plug-us-reddit]: https://www.reddit.com/r/homeautomation/comments/ps9iey/
 [shelly-plug-us-aoycocr]: https://devices.esphome.io/devices/Aoycocr-X10S-Plug/
 [shelly-plug-us-fcc]: https://fccid.io/2ALAY-SHELLY

--- a/src/docs/devices/Sinilink-XY-VFMS/index.md
+++ b/src/docs/devices/Sinilink-XY-VFMS/index.md
@@ -30,8 +30,7 @@ adapter for 6x1.25mm but the Vin- screw terminal could also be used for conveien
 The following configuration is adapted from [this ESPHome devices repository][1] with only minor changes to fit the new
 device.
 
-[1]:
-https://github.com/esphome/esphome-devices/blob/main/src/docs/devices/Sinilink-XY-WFUSB-USB-Switch-Relay/index.md
+[1]: /devices/Sinilink-XY-WFUSB-USB-Switch-Relay/
 
 There is a 3D printable case available from
 [https://www.thingiverse.com/thing:4146127](https://www.thingiverse.com/thing:4146127)

--- a/src/docs/devices/Sinilink-XY-VFMS/index.md
+++ b/src/docs/devices/Sinilink-XY-VFMS/index.md
@@ -27,8 +27,8 @@ adapter for 6x1.25mm but the Vin- screw terminal could also be used for conveien
 
 ## Basic Config
 
-The following configuration is adapted from [this ESPHome devices repository][1] with only minor changes to fit the new
-device.
+The following configuration is adapted from the [Sinilink XY-WFUSB USB Switch Relay][1] device page with only minor
+changes to fit the new device.
 
 [1]: /devices/Sinilink-XY-WFUSB-USB-Switch-Relay/
 

--- a/src/docs/devices/adding-devices.mdx
+++ b/src/docs/devices/adding-devices.mdx
@@ -78,8 +78,8 @@ import ValidOptions from "@components/ValidOptions.astro";
 
 ### Step 1: Fork the repository
 
-Go to [github.com/esphome/esphome-devices/fork](https://github.com/esphome/esphome-devices/fork) and click
-**Create fork**. This gives you your own copy of the repo at `github.com/<your-username>/esphome-devices`.
+Go to [github.com/esphome/devices.esphome.io/fork](https://github.com/esphome/devices.esphome.io/fork) and click
+**Create fork**. This gives you your own copy of the repo at `github.com/<your-username>/devices.esphome.io`.
 
 Once your fork is created, **come back to this page** to continue.
 
@@ -94,7 +94,7 @@ the device name, and it will open GitHub's new file page with the filename and f
     <input
       id="quickstart-username"
       type="text"
-      placeholder="https://github.com/octocat/esphome-devices"
+      placeholder="https://github.com/octocat/devices.esphome.io"
       spellcheck="false"
       autocapitalize="off"
       autocorrect="off"
@@ -176,11 +176,11 @@ Click **Commit changes...** at the top right. A dialog will appear:
 ### Step 5: Open the pull request
 
 GitHub will take you to the pull request page automatically. Check that the base repository is
-`esphome/esphome-devices` and the base branch is `main`, then click **Create pull request** to submit it.
+`esphome/devices.esphome.io` and the base branch is `main`, then click **Create pull request** to submit it.
 
-If the base repository is set to your own fork instead of `esphome/esphome-devices`, click the
+If the base repository is set to your own fork instead of `esphome/devices.esphome.io`, click the
 **compare across forks** link near the top of the page. That will reveal the **base repository** dropdown — switch it
-to `esphome/esphome-devices` and make sure the base branch is `main` before clicking **Create pull request**.
+to `esphome/devices.esphome.io` and make sure the base branch is `main` before clicking **Create pull request**.
 
 ## YAML Front Matter
 

--- a/src/integrations/remark-yaml-include.ts
+++ b/src/integrations/remark-yaml-include.ts
@@ -39,7 +39,7 @@ const URL_HOST_ALLOWLIST = new Set(["github.com", "raw.githubusercontent.com"]);
 // users can paste into their own ESPHome config to pull this device's yaml
 // straight from GitHub. Tracks the editLink baseUrl in astro.config.mjs.
 const REPO_OWNER = "esphome";
-const REPO_NAME = "esphome-devices";
+const REPO_NAME = "devices.esphome.io";
 const REPO_BRANCH = "main";
 
 function stripAttrs(meta: string, ...attrs: string[]): string {


### PR DESCRIPTION
# Brief description of the changes

The GitHub repo has been renamed from `esphome/esphome-devices` to `esphome/devices.esphome.io`. This updates the references that pointed at the old repo slug: the sidebar/footer GitHub links, the Starlight `editLink` base URL, the `REPO_NAME` used to build the one-click `!include github://…` directives, and the `DEFAULT_REPO` fallback in the fork-link generator plus the fork instructions in the adding-devices guide. A couple of device pages that linked to upstream blob URLs now use their rendered site URLs instead, and the stale `esphome-devices.com` mention in the device-config issue template is corrected to `devices.esphome.io`. The public domain is unchanged (already `devices.esphome.io`); only GitHub repo-slug references are affected, and user-fork links are intentionally left alone.

## Type of changes

- [ ] New device
- [ ] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [x] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.