### PR TITLE
Fix date-published workflow failing on fork PRs (no secrets)

### DIFF
--- a/.github/workflows/commit-date-published.yml
+++ b/.github/workflows/commit-date-published.yml
@@ -1,0 +1,166 @@
+name: Commit date-published update
+
+# Runs in the trusted base-repo context after the fork-PR workflow finishes,
+# so it has access to the GitHub App credentials that update-date-published.yml
+# cannot see. It consumes the metadata artifact produced there, rewrites the
+# date-published frontmatter, and commits back to the PR branch.
+on:
+  workflow_run:
+    workflows: ["Update date-published on approval"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  commit:
+    name: Update date-published and push
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read  # download the metadata artifact from the triggering run
+    steps:
+      - name: Download metadata
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: date-published-metadata
+          path: metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # The triggering workflow only uploads an artifact when it found newly
+      # added device pages, so its absence means there is nothing to do.
+      - name: Read metadata
+        id: meta
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('metadata/info.json')) {
+              core.info('No metadata artifact — nothing to do.');
+              core.setOutput('proceed', 'false');
+              return;
+            }
+            const m = JSON.parse(fs.readFileSync('metadata/info.json', 'utf8'));
+            core.setOutput('proceed', 'true');
+            core.setOutput('head_repo', m.headRepo);
+            core.setOutput('head_ref', m.headRef);
+            core.setOutput('head_sha', m.headSha);
+            core.setOutput('pages', m.pages.join('\n'));
+
+      - name: Generate a token
+        if: steps.meta.outputs.proceed == 'true'
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Checkout PR branch
+        if: steps.meta.outputs.proceed == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ steps.meta.outputs.head_repo }}
+          # Pin to the immutable approved SHA, not the mutable branch ref.
+          # If a contributor pushes between approval and this workflow
+          # running, the createCommitOnBranch expectedHeadOid check below
+          # will see the branch has moved past head.sha and fail loudly —
+          # the safe behavior, rather than silently rewriting whatever the
+          # branch tip now happens to be.
+          ref: ${{ steps.meta.outputs.head_sha }}
+          token: ${{ steps.generate-token.outputs.token }}
+
+      # Domain-specific: rewrite the date-published frontmatter line in each
+      # newly added device page, and emit the list of files actually changed
+      # so the commit step below can be kept generic.
+      - name: Update date-published
+        if: steps.meta.outputs.proceed == 'true'
+        id: update
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          PAGES: ${{ steps.meta.outputs.pages }}
+        with:
+          script: |
+            const fs = require('fs');
+            const pages = (process.env.PAGES || '')
+              .split('\n')
+              .filter(Boolean);
+            const today = new Date().toISOString().slice(0, 10);
+            const changed = [];
+            for (const path of pages) {
+              if (!fs.existsSync(path)) {
+                core.warning(`Skipping ${path} — not present in checkout`);
+                continue;
+              }
+              const text = fs.readFileSync(path, 'utf8');
+              const match = text.match(/^(date-published:[ \t]*)(\S+)/m);
+              if (!match) {
+                core.warning(`No date-published field in ${path}`);
+                continue;
+              }
+              if (match[2] === today) {
+                core.info(`${path} already on ${today}`);
+                continue;
+              }
+              const updated = text.replace(
+                /^(date-published:[ \t]*).*$/m,
+                `$1${today}`,
+              );
+              fs.writeFileSync(path, updated);
+              core.info(`Updated ${path}: ${match[2]} -> ${today}`);
+              changed.push(path);
+            }
+            core.setOutput('paths', changed.join('\n'));
+
+      - name: Commit changes via createCommitOnBranch
+        if: steps.meta.outputs.proceed == 'true' && steps.update.outputs.paths != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          PATHS: ${{ steps.update.outputs.paths }}
+          MESSAGE: Update date-published to date of approval
+          REPOSITORY: ${{ steps.meta.outputs.head_repo }}
+          BRANCH: ${{ steps.meta.outputs.head_ref }}
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+            const repository = process.env.REPOSITORY;
+            const branchName = process.env.BRANCH;
+            const message = process.env.MESSAGE;
+            const paths = (process.env.PATHS || '')
+              .split('\n')
+              .filter(Boolean);
+
+            // Use the SHA we actually checked out as the optimistic-lock
+            // value — if anyone pushed between checkout and now, the
+            // mutation fails rather than silently overwriting their commit.
+            const { stdout } = await exec.getExecOutput(
+              'git', ['rev-parse', 'HEAD'],
+            );
+            const expectedHeadOid = stdout.trim();
+
+            const additions = paths.map((p) => ({
+              path: p,
+              contents: fs.readFileSync(p).toString('base64'),
+            }));
+
+            const result = await github.graphql(
+              `mutation($input: CreateCommitOnBranchInput!) {
+                createCommitOnBranch(input: $input) {
+                  commit { url oid }
+                }
+              }`,
+              {
+                input: {
+                  branch: {
+                    repositoryNameWithOwner: repository,
+                    branchName,
+                  },
+                  message: { headline: message },
+                  expectedHeadOid,
+                  fileChanges: { additions },
+                },
+              },
+            );
+            const commit = result.createCommitOnBranch.commit;
+            core.info(`Created verified commit ${commit.oid}: ${commit.url}`);

--- a/.github/workflows/update-date-published.yml
+++ b/.github/workflows/update-date-published.yml
@@ -6,9 +6,14 @@ on:
 
 permissions: {}
 
+# This workflow runs in the (untrusted) fork-PR context and therefore has no
+# access to secrets or variables. It only discovers which device pages were
+# newly added and hands that data to commit-date-published.yml via an
+# artifact; the privileged token generation and commit happen there, in the
+# trusted workflow_run context.
 jobs:
-  pre-check:
-    name: Find newly added device pages
+  collect:
+    name: Collect newly added device pages
     runs-on: ubuntu-latest
     if: >-
       github.event.review.state == 'approved' &&
@@ -16,14 +21,18 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    outputs:
-      pages: ${{ steps.find.outputs.pages }}
     steps:
       - name: Find newly added device pages
         id: find
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |
+            const fs = require('fs');
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -31,132 +40,33 @@ jobs:
               per_page: 100,
             });
             const pattern = /^src\/docs\/devices\/[^/]+\/index\.md$/;
-            const added = files
+            const pages = files
               .filter(f => f.status === 'added' && pattern.test(f.filename))
               .map(f => f.filename);
             core.info(
-              `Found ${added.length} newly added device page(s): ` +
-              `${added.join(', ') || '(none)'}`
+              `Found ${pages.length} newly added device page(s): ` +
+              `${pages.join(', ') || '(none)'}`
             );
-            core.setOutput('pages', added.join('\n'));
+            core.setOutput('pages', pages.join('\n'));
+            if (pages.length === 0) return;
+            // Capture the PR coordinates the trusted workflow needs. The
+            // commit workflow cannot recover these from github.event.workflow_run
+            // for fork PRs (its pull_requests array is empty), so pass them
+            // explicitly through the artifact.
+            const metadata = {
+              prNumber: Number(process.env.PR_NUMBER),
+              headRepo: process.env.HEAD_REPO,
+              headRef: process.env.HEAD_REF,
+              headSha: process.env.HEAD_SHA,
+              pages,
+            };
+            fs.mkdirSync('metadata', { recursive: true });
+            fs.writeFileSync('metadata/info.json', JSON.stringify(metadata));
 
-  update-date:
-    name: Update date-published and push
-    needs: pre-check
-    if: needs.pre-check.outputs.pages != ''
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+      - name: Upload metadata
+        if: steps.find.outputs.pages != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
-
-      - name: Checkout PR branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          # Pin to the immutable approved SHA, not the mutable branch ref.
-          # If a contributor pushes between approval and this workflow
-          # running, the createCommitOnBranch expectedHeadOid check below
-          # will see the branch has moved past head.sha and fail loudly —
-          # the safe behavior, rather than silently rewriting whatever the
-          # branch tip now happens to be.
-          ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{ steps.generate-token.outputs.token }}
-
-      # Domain-specific: rewrite the date-published frontmatter line in each
-      # newly added device page, and emit the list of files actually changed
-      # so the commit step below can be kept generic.
-      - name: Update date-published
-        id: update
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        env:
-          PAGES: ${{ needs.pre-check.outputs.pages }}
-        with:
-          script: |
-            const fs = require('fs');
-            const pages = (process.env.PAGES || '')
-              .split('\n')
-              .filter(Boolean);
-            const today = new Date().toISOString().slice(0, 10);
-            const changed = [];
-            for (const path of pages) {
-              if (!fs.existsSync(path)) {
-                core.warning(`Skipping ${path} — not present in checkout`);
-                continue;
-              }
-              const text = fs.readFileSync(path, 'utf8');
-              const match = text.match(/^(date-published:[ \t]*)(\S+)/m);
-              if (!match) {
-                core.warning(`No date-published field in ${path}`);
-                continue;
-              }
-              if (match[2] === today) {
-                core.info(`${path} already on ${today}`);
-                continue;
-              }
-              const updated = text.replace(
-                /^(date-published:[ \t]*).*$/m,
-                `$1${today}`,
-              );
-              fs.writeFileSync(path, updated);
-              core.info(`Updated ${path}: ${match[2]} -> ${today}`);
-              changed.push(path);
-            }
-            core.setOutput('paths', changed.join('\n'));
-
-      - name: Commit changes via createCommitOnBranch
-        if: steps.update.outputs.paths != ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        env:
-          PATHS: ${{ steps.update.outputs.paths }}
-          MESSAGE: Update date-published to date of approval
-          REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          BRANCH: ${{ github.event.pull_request.head.ref }}
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            const fs = require('fs');
-            const repository = process.env.REPOSITORY;
-            const branchName = process.env.BRANCH;
-            const message = process.env.MESSAGE;
-            const paths = (process.env.PATHS || '')
-              .split('\n')
-              .filter(Boolean);
-
-            // Use the SHA we actually checked out as the optimistic-lock
-            // value — if anyone pushed between checkout and now, the
-            // mutation fails rather than silently overwriting their commit.
-            const { stdout } = await exec.getExecOutput(
-              'git', ['rev-parse', 'HEAD'],
-            );
-            const expectedHeadOid = stdout.trim();
-
-            const additions = paths.map((p) => ({
-              path: p,
-              contents: fs.readFileSync(p).toString('base64'),
-            }));
-
-            const result = await github.graphql(
-              `mutation($input: CreateCommitOnBranchInput!) {
-                createCommitOnBranch(input: $input) {
-                  commit { url oid }
-                }
-              }`,
-              {
-                input: {
-                  branch: {
-                    repositoryNameWithOwner: repository,
-                    branchName,
-                  },
-                  message: { headline: message },
-                  expectedHeadOid,
-                  fileChanges: { additions },
-                },
-              },
-            );
-            const commit = result.createCommitOnBranch.commit;
-            core.info(`Created verified commit ${commit.oid}: ${commit.url}`);
+          name: date-published-metadata
+          path: metadata/info.json
+          retention-days: 1


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

The approval-triggered `update-date-published.yml` runs in the `pull_request_review` context of a fork PR, where GitHub withholds secrets and configuration variables. `vars.ESPHOME_GITHUB_APP_CLIENT_ID` resolved to an empty string and `actions/create-github-app-token` failed with "the 'client-id' input must be set to a non-empty string" (e.g. [run on #1560](https://github.com/esphome/devices.esphome.io/actions/runs/26919450829/job/79416615554)).

This splits the flow in two. `update-date-published.yml` now only runs in the untrusted fork context: it detects newly added device pages and uploads the PR coordinates + page list as an artifact — no secrets needed. A new `commit-date-published.yml`, triggered by `workflow_run` on that workflow's completion, runs in the trusted base-repo context (where secrets are available), downloads the artifact, generates the app token, checks out the approved head SHA, rewrites the `date-published` frontmatter, and commits via `createCommitOnBranch`. The fork's code is checked out but never executed, so secrets are not exposed to untrusted code.

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [ ] The first `file=` fence on the page references `config.yaml`.
- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->