### PR TITLE
Allow yaml fences to opt out of file extraction with an inline marker

### DIFF
--- a/scripts/extract-inline-yaml.ts
+++ b/scripts/extract-inline-yaml.ts
@@ -41,6 +41,7 @@ interface MetaAttrs {
   fileAttr?: { value: string; quoted: boolean };
   urlAttr?: { value: string; quoted: boolean };
   title?: { value: string; quoted: boolean };
+  inline?: boolean;
   raw: string;
 }
 
@@ -63,6 +64,8 @@ function parseMeta(meta: string): MetaAttrs {
     else if (key === "url") out.urlAttr = { value, quoted };
     else if (key === "title") out.title = { value, quoted };
   }
+  // Bare `inline` marker (no `=value`) opts the snippet out of extraction.
+  out.inline = /(^|\s)inline(?=\s|$)/.test(meta);
   return out;
 }
 
@@ -254,6 +257,11 @@ function processFile(absPath: string, opts: { dryRun: boolean }): ProcessResult 
     if (lang !== "yaml" && lang !== "yml") continue;
 
     const meta = parseMeta(fence.meta);
+
+    // `inline` opts a small snippet out of extraction. Leave it verbatim and
+    // don't let it consume the "first fence is config.yaml" slot.
+    if (meta.inline && !meta.fileAttr && !meta.urlAttr) continue;
+
     const isFirstFence = yamlFenceIndex === 0;
     yamlFenceIndex++;
 

--- a/scripts/validate-yaml-configs.ts
+++ b/scripts/validate-yaml-configs.ts
@@ -213,6 +213,7 @@ function checkSensitiveInTree(
 interface YamlFence {
   fileAttr: string | null; // null when the fence has no `file=` attr
   urlAttr: string | null; // null when the fence has no `url=` attr
+  inline: boolean; // true when the fence carries the bare `inline` marker
   lineNumber: number; // 1-indexed source line of the fence opener
 }
 
@@ -245,7 +246,8 @@ function findYamlFences(md: string): YamlFence[] {
     const urlAttr = urlMatch
       ? urlMatch[2] ?? urlMatch[3] ?? urlMatch[4] ?? ""
       : null;
-    fences.push({ fileAttr, urlAttr, lineNumber: i + 1 });
+    const inline = /(^|\s)inline(?=\s|$)/.test(meta);
+    fences.push({ fileAttr, urlAttr, inline, lineNumber: i + 1 });
   }
   return fences;
 }
@@ -570,8 +572,10 @@ function main(): void {
         // A fence is "inline" only when it has neither `file=` nor `url=`.
         // `url=` blocks pull from the manufacturer's repo at visit time —
         // they're a valid migrated form for made-for-esphome devices that
-        // don't want their config vendored into this repo.
-        if (f.fileAttr === null && f.urlAttr === null) {
+        // don't want their config vendored into this repo. The bare `inline`
+        // marker is an explicit opt-out for tiny snippets that shouldn't be
+        // extracted to a file at all.
+        if (f.fileAttr === null && f.urlAttr === null && !f.inline) {
           issues.push({
             file: rel,
             line: f.lineNumber,

--- a/src/docs/devices/adding-devices.mdx
+++ b/src/docs/devices/adding-devices.mdx
@@ -243,6 +243,24 @@ The script is idempotent — it leaves already-migrated fences alone and writes 
 `config.yaml`. Quotes around the file attribute are optional (`file=config.yaml` and `file="config.yaml"` both
 parse).
 
+### Small snippets that stay inline (`inline` marker)
+
+The `file=` rule exists so full example configs live in their own files. For a very small illustrative snippet —
+a couple of lines showing one option, not a runnable config — extracting it to a file is overkill. Mark the fence
+`inline` and it stays on the page verbatim; the validator and `npm run extract-yaml` both leave it alone.
+
+````md
+```yaml inline
+sensor:
+  - platform: adc
+    pin: GPIO34
+```
+````
+
+Use this only for short snippets. Anything that is (or grows into) a real, runnable config belongs in its own
+`.yaml` file via `file=` — `inline` is not an escape hatch for skipping the no-passwords / no-`!secret` rules on a
+full config.
+
 ### Live yaml from a GitHub URL (`url=` form)
 
 For made-for-ESPHome devices whose configuration lives in the manufacturer's own GitHub repository, you can point

--- a/src/integrations/remark-yaml-include.ts
+++ b/src/integrations/remark-yaml-include.ts
@@ -27,6 +27,9 @@ import type { VFile } from "vfile";
 
 const FILE_ATTR = /(^|\s)file=(?:"([^"]+)"|'([^']+)'|([^\s"']+))/;
 const URL_ATTR = /(^|\s)url=(?:"([^"]+)"|'([^']+)'|([^\s"']+))/;
+// Bare `inline` marker (no `=value`) opting a small snippet out of file
+// extraction. The validator and extractor honour it too.
+const INLINE_ATTR = /(^|\s)inline(?=\s|$)/;
 const YAML_LANGS = new Set(["yaml", "yml"]);
 
 // Hosts a `url=` fence may point at. We don't want a device page to be able
@@ -143,6 +146,15 @@ const remarkYamlInclude: Plugin<[], Root> = () => {
     visitCodeNodes(tree, (parent, index, node) => {
       const lang = (node.lang ?? "").toLowerCase();
       if (!YAML_LANGS.has(lang)) return;
+
+      // `inline` keeps a small snippet on the page verbatim instead of
+      // extracting it to a sibling yaml file. Strip the marker so it never
+      // leaks into the rendered fence meta; the rest of the pipeline then
+      // highlights the block as an ordinary inline yaml fence.
+      if (node.meta && INLINE_ATTR.test(node.meta)) {
+        const stripped = node.meta.replace(INLINE_ATTR, "").replace(/\s+/g, " ").trim();
+        node.meta = stripped.length > 0 ? stripped : null;
+      }
 
       const filePath = extractAttr(FILE_ATTR, node.meta);
       const url = extractAttr(URL_ATTR, node.meta);


### PR DESCRIPTION
# Brief description of the changes

Adds an `inline` marker for yaml fenced code blocks so very small illustrative snippets can stay on the page verbatim instead of being extracted into a sibling `.yaml` file. Writing ```` ```yaml inline ```` opts a fence out of extraction: the remark plugin strips the marker before rendering (preserving any other meta), `validate-yaml-configs.ts` no longer rejects it on added/modified pages, and `extract-inline-yaml.ts` leaves it untouched without consuming the "first fence is config.yaml" slot. This is intended only for short snippets — real, runnable configs still belong in their own `file=` yaml. The `adding-devices` docs gain a section documenting the marker and its caveats.

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [ ] The first `file=` fence on the page references `config.yaml`.
- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->