### PR TITLE
Update device information for eWelink relay

### DIFF
--- a/src/docs/devices/eWelink-5V-12V-Inching-Relay/index.md
+++ b/src/docs/devices/eWelink-5V-12V-Inching-Relay/index.md
@@ -12,6 +12,9 @@ difficulty: 4
 - This device is advertised in eWelink as _Coolkit 0185_, which is a generic name used for more devices
 - Has a red LED attached to the relay output that cannot be controlled independently
 - Has a button for RF pairing, but the unit tested had no RF radio meaning it's a useless button
+- **Important:** *newer versions* of this device (e.g., labelled as `EWL-B04`) use a Bouffalo based MCU, such as the `BL602`.
+  You can *not* flash ESPHome on them, but could use OpenBeken and MQTT for an integration with Home Assistant.
+  See [this thread](https://www.elektroda.com/rtvforum/topic3889041.html) for a comprehensive discussion on the topic.
 
 ## Product Images
 


### PR DESCRIPTION
Added note about newer device versions using Bouffalo MCU and integration options.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Added link to description of newer hardware -incompatible with ESPHome- on this device.

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [x] Adding a new device adds a single device only — one device per pull request.
- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [x] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
