### PR TITLE
Documentation update for two Tuya IR blasters

### DIFF
--- a/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/config.yaml
+++ b/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/config.yaml
@@ -1,0 +1,35 @@
+bk72xx:
+  board: generic-bk7231n-qfn32-tuya
+
+output:
+  - platform: libretiny_pwm
+    id: led
+    pin: 24
+
+light:
+  - platform: monochromatic
+    name: LED
+    output: led
+
+binary_sensor:
+  - platform: gpio
+    id: btn
+    pin:
+      number: 9
+      mode:
+        input: true
+        pullup: true
+      inverted: true
+
+remote_transmitter:
+  pin: 7
+  carrier_duty_percent: 50%
+
+remote_receiver:
+  pin:
+    number: 8
+    inverted: true
+    mode:
+      input: true
+      pullup: true
+  tolerance: 55%

--- a/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/index.md
+++ b/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/index.md
@@ -14,7 +14,8 @@ There's detailed teardown info at [Elektroda](https://www.elektroda.com/rtvforum
 Despite appearing outwardly identical to the
 [Tuya Generic IR Remote Control](/devices/Tuya-Generic-WiFi-IR-Remote-Control), the IRC03 has a custom PCB with the
 BK7231N directly integrated into it as opposed to using the CB3S module. The pinouts between the two devices differ as a
-result.
+result. You can determine which board you have by shining a flashlight through the casing; on this model, the PCB is a
+single solid board with no cutouts.
 
 ![IRC03](IRC03.jpg)
 

--- a/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/index.md
+++ b/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/index.md
@@ -39,42 +39,7 @@ flash ESPHome Kickstart to the device, from which I uploaded a proper UF2 binary
 
 ## Configuration
 
-```yaml
-bk72xx:
-  board: generic-bk7231n-qfn32-tuya
-
-output:
-  - platform: libretiny_pwm
-    id: led
-    pin: 24
-
-light:
-  - platform: monochromatic
-    name: LED
-    output: led
-
-binary_sensor:
-  - platform: gpio
-    id: btn
-    pin:
-      number: 9
-      mode:
-        input: true
-        pullup: true
-      inverted: true
-
-remote_transmitter:
-  pin: 7
-  carrier_duty_percent: 50%
-
-remote_receiver:
-  pin:
-    number: 8
-    inverted: true
-    mode:
-      input: true
-      pullup: true
-  tolerance: 55%
+```yaml file=config.yaml
 ```
 
 If you're attempting to use this with raw IR commands with an integration such as SmartIR, make sure that you set the
@@ -82,34 +47,14 @@ carrier frequency accordingly. Not setting this may result in otherwise valid co
 anticipated or at all. Valid frequencies typically range betweeen 33-40 kHz or 50-60 kHz, with the most common protocol,
 the NEC protocol, using a frequency of 38 kHz.
 
-```yaml
-api:
-  encryption:
-    key: "xxxxxxx"
-  services:
-    - service: send_raw_command
-      variables:
-        command: int[]
-      then:
-        - remote_transmitter.transmit_raw:
-            code: !lambda "return command;"
-            carrier_frequency: !lambda "return 38000.0;"
+```yaml file=services.yaml
 ```
 
 If you don't know the carrier frequency, and the NEC default of 38 kHz doesn't work, you can find out what your device's
 frequency is by dumping a code from your existing remote. First, modify the `remote_receiver` definition in the ESPHome
 configuration to dump the codes in Pronto form. These include the carrier frequency embedded in them.
 
-```yaml
-remote_receiver:
-  pin:
-    number: 8
-    inverted: true
-    mode:
-      input: true
-      pullup: true
-  tolerance: 55%
-  dump: pronto
+```yaml file=receiver.yaml
 ```
 
 Once you flash the firmware, keep the device logs open within ESPHome Device Builder. Take the remote for your device,

--- a/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/receiver.yaml
+++ b/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/receiver.yaml
@@ -1,0 +1,9 @@
+remote_receiver:
+  pin:
+    number: 8
+    inverted: true
+    mode:
+      input: true
+      pullup: true
+  tolerance: 55%
+  dump: pronto

--- a/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/services.yaml
+++ b/src/docs/devices/Tuya-Generic-IRC03-IR-Blaster/services.yaml
@@ -1,0 +1,11 @@
+api:
+  encryption:
+    key: "xxxxxxx"
+  services:
+    - service: send_raw_command
+      variables:
+        command: int[]
+      then:
+        - remote_transmitter.transmit_raw:
+            code: !lambda "return command;"
+            carrier_frequency: !lambda "return 38000.0;"

--- a/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/config.yaml
+++ b/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/config.yaml
@@ -1,0 +1,25 @@
+bk72xx:
+  board: cb3s
+
+remote_receiver:
+  pin:
+    number: P7
+    inverted: true
+    mode: INPUT_PULLUP
+
+remote_transmitter:
+  pin: P26
+  carrier_duty_percent: 50%
+
+light:
+  - platform: status_led
+    pin: P8
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: P6
+      inverted: true
+      mode:
+        input: true
+        pullup: true

--- a/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/index.md
+++ b/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/index.md
@@ -4,6 +4,7 @@ date-published: 2025-02-22
 type: misc
 standard: global
 board: bk72xx
+difficulty: 2
 ---
 
 ## General Notes
@@ -14,8 +15,8 @@ This device has a CB3S board. It can be bought [on Aliexpress](https://www.aliex
 Despite appearing outwardly identical to the [Tuya Generic IRC03 IR Blaster](/devices/Tuya-Generic-IRC03-IR-Blaster),
 the IRC03 has a custom PCB with the BK7231N directly integrated into it as opposed to using the CB3S module. The pinouts
 between the two devices differ as a result. You can determine which board you have by shining a flashlight through the
-casing; on this model, there's a rectangular cutout on the PCB opposite the USB port through which you can see the 
-underside of the CB3S module. 
+casing; on this model, there's a rectangular cutout on the PCB opposite the USB port through which you can see the
+underside of the CB3S module.
 
 ![IRRemote](tuya-generic-wifi-ir-remote-control.jpg)
 

--- a/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/index.md
+++ b/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/index.md
@@ -33,7 +33,7 @@ underside of the CB3S module.
 
 This device can be flashed using [Tuya Cloudcutter](https://github.com/tuya-cloudcutter/tuya-cloudcutter) using device
 profile _tuya-generic-universal-ir-remote-control-cb3s-v2.0.0_. Once flashed, you can upload a custom firmware with the
-following configuration through the ESPHome Kickstart interface, or adopt it into your ESPHome dashboard. 
+following configuration through the ESPHome Kickstart interface, or adopt it into your ESPHome dashboard.
 
 ## Configuration
 

--- a/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/index.md
+++ b/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/index.md
@@ -8,12 +8,14 @@ board: bk72xx
 
 ## General Notes
 
-This devices has a CB3S board. It can be bought [on Aliexpress](https://www.aliexpress.com/item/1005007804859733.html)
+This device has a CB3S board. It can be bought [on Aliexpress](https://www.aliexpress.com/item/1005007804859733.html)
 (February 2025).
 
 Despite appearing outwardly identical to the [Tuya Generic IRC03 IR Blaster](/devices/Tuya-Generic-IRC03-IR-Blaster),
 the IRC03 has a custom PCB with the BK7231N directly integrated into it as opposed to using the CB3S module. The pinouts
-between the two devices differ as a result.
+between the two devices differ as a result. You can determine which board you have by shining a flashlight through the
+casing; on this model, there's a rectangular cutout on the PCB opposite the USB port through which you can see the 
+underside of the CB3S module. 
 
 ![IRRemote](tuya-generic-wifi-ir-remote-control.jpg)
 
@@ -29,7 +31,8 @@ between the two devices differ as a result.
 ## Flashing
 
 This device can be flashed using [Tuya Cloudcutter](https://github.com/tuya-cloudcutter/tuya-cloudcutter) using device
-profile _tuya-generic-universal-ir-remote-control-cb3s-v2.0.0_.
+profile _tuya-generic-universal-ir-remote-control-cb3s-v2.0.0_. Once flashed, you can upload a custom firmware with the
+following configuration through the ESPHome Kickstart interface, or adopt it into your ESPHome dashboard. 
 
 ## Configuration
 

--- a/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/index.md
+++ b/src/docs/devices/Tuya-Generic-WiFi-IR-Remote-Control/index.md
@@ -37,30 +37,5 @@ following configuration through the ESPHome Kickstart interface, or adopt it int
 
 ## Configuration
 
-```yaml
-bk72xx:
-  board: cb3s
-
-remote_receiver:
-  pin:
-    number: P7
-    inverted: true
-    mode: INPUT_PULLUP
-
-remote_transmitter:
-  pin: P26
-  carrier_duty_percent: 50%
-
-light:
-  - platform: status_led
-    pin: P8
-
-binary_sensor:
-  - platform: gpio
-    pin:
-      number: P6
-      inverted: true
-      mode:
-        input: true
-        pullup: true
+```yaml file=config.yaml
 ```


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Added a small bit of additional documentation to the Tuya Generic IR Blaster and Tuya IRC03 IR Blaster to help differentiate the two physically, since they're outwardly identical. 

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
