### PR TITLE
docs: fix warning image link

### DIFF
--- a/src/docs/devices/Gosund-SP111/index.md
+++ b/src/docs/devices/Gosund-SP111/index.md
@@ -8,7 +8,7 @@ board: esp8266
 
 ## Warning
 
-![Warning](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/260px-Warning.svg.png)
+![Warning](https://upload.wikimedia.org/wikipedia/commons/1/17/Warning.svg)
 
 Looks like device chip was replaced to non-flashable custom tasmota chip.
 

--- a/src/docs/devices/Nous-A1/index.md
+++ b/src/docs/devices/Nous-A1/index.md
@@ -7,7 +7,7 @@ standard: eu
 
 ## Warning
 
-![Warning](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/260px-Warning.svg.png)
+![Warning](https://upload.wikimedia.org/wikipedia/commons/1/17/Warning.svg)
 
 Looks like device chip was replaced to non-flashable custom tasmota chip.
 


### PR DESCRIPTION
Summary
- Replaces the broken Wikimedia warning thumbnail URL in the Gosund SP111 and Nous A1 device pages.
- Uses the same Wikimedia file's direct SVG URL, which returns a successful image response.
- Keeps the change scoped to the two affected Markdown links from #1576.

Validation
- `curl.exe -L -I --max-time 20 https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/260px-Warning.svg.png` returned HTTP 400.
- `curl.exe -L -I --max-time 20 https://upload.wikimedia.org/wikipedia/commons/1/17/Warning.svg` returned HTTP 200 with `content-type: image/svg+xml`.
- `npm ci` passed.
- `npm run --silent check-links -- --annotations` passed for `upstream/main..HEAD`.
- `npm run --silent lint-frontmatter -- --annotations` passed for `upstream/main..HEAD` after adding yamllint to a local validation venv.
- `npx --yes markdownlint-cli@0.45.0 src/docs/devices/Gosund-SP111/index.md src/docs/devices/Nous-A1/index.md` passed.
- `git diff --check upstream/main..HEAD` passed.

Notes
- Addresses part of #1576.
- Docs-only image URL update; no compatibility impact expected.
- Full site build was not run locally because this checkout was sparse to avoid clone timeouts; changed-link and frontmatter checks were run against the PR diff.