### PR TITLE
Add Remko RKL 355 ECO

### DIFF
--- a/src/docs/devices/Remko-RKL-355-Eco/circuit.svg
+++ b/src/docs/devices/Remko-RKL-355-Eco/circuit.svg
@@ -1,0 +1,1086 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Circuit Diagram, cdlibrary.dll 4.0.0.0 -->
+
+<svg
+   version="1.1"
+   width="720"
+   height="560"
+   id="svg97"
+   sodipodi:docname="circuit.svg"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs97" />
+  <sodipodi:namedview
+     id="namedview97"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.1376843"
+     inkscape:cx="339.28569"
+     inkscape:cy="164.80846"
+     inkscape:window-width="1920"
+     inkscape:window-height="1151"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg97"
+     showgrid="false" />
+  <rect
+     style="fill:#ffffff;stroke:none;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+     id="rect1"
+     width="709.33563"
+     height="548.48254"
+     x="6.1528492"
+     y="6.1528492" />
+  <line
+     x1="430"
+     y1="180"
+     x2="430"
+     y2="340"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line1" />
+  <line
+     x1="430"
+     y1="390"
+     x2="430"
+     y2="400"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line2" />
+  <line
+     x1="430"
+     y1="340"
+     x2="430"
+     y2="345"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line3" />
+  <line
+     x1="430"
+     y1="385"
+     x2="430"
+     y2="390"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line4" />
+  <rect
+     x="422"
+     y="345"
+     width="16"
+     height="40"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="rect4" />
+  <text
+     x="416"
+     y="365"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 416, 365)"
+     id="text4">4.7 kΩ</text>
+  <line
+     x1="360"
+     y1="400"
+     x2="430"
+     y2="400"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line5" />
+  <line
+     x1="430"
+     y1="180"
+     x2="580"
+     y2="180"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line6" />
+  <line
+     x1="20"
+     y1="110"
+     x2="20"
+     y2="440"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line7" />
+  <line
+     x1="20"
+     y1="440"
+     x2="220"
+     y2="440"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line8" />
+  <line
+     x1="300"
+     y1="510"
+     x2="300"
+     y2="520"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line9" />
+  <line
+     x1="300"
+     y1="440"
+     x2="300"
+     y2="460"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line10" />
+  <line
+     x1="270"
+     y1="440"
+     x2="320"
+     y2="440"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line11" />
+  <line
+     x1="360"
+     y1="460"
+     x2="360"
+     y2="520"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line12" />
+  <line
+     x1="360"
+     y1="330"
+     x2="360"
+     y2="340"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line13" />
+  <line
+     x1="360"
+     y1="390"
+     x2="360"
+     y2="410"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line14" />
+  <line
+     x1="360"
+     y1="410"
+     x2="360"
+     y2="420"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line15" />
+  <path
+     d="M 355,320 L 365,320 L 360,310 L 355,320 Z"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="path15" />
+  <text
+     x="354"
+     y="314"
+     style="font-family:Arial;font-size:12px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 354, 314)"
+     id="text15">+5V</text>
+  <line
+     x1="360"
+     y1="320"
+     x2="360"
+     y2="330"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line16" />
+  <line
+     x1="360"
+     y1="520"
+     x2="360"
+     y2="522"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line17" />
+  <path
+     d="M 352,522 L 368,522 L 360,530 L 352,522 Z"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="path17" />
+  <line
+     x1="300"
+     y1="520"
+     x2="300"
+     y2="522"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line18" />
+  <path
+     d="M 292,522 L 308,522 L 300,530 L 292,522 Z"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="path18" />
+  <line
+     x1="290"
+     y1="290"
+     x2="290"
+     y2="300"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line19" />
+  <line
+     x1="230"
+     y1="240"
+     x2="230"
+     y2="300"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line20" />
+  <line
+     x1="400"
+     y1="160"
+     x2="580"
+     y2="160"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line21" />
+  <line
+     x1="400"
+     y1="160"
+     x2="400"
+     y2="220"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line22" />
+  <line
+     x1="360"
+     y1="220"
+     x2="400"
+     y2="220"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line23" />
+  <line
+     x1="290"
+     y1="220"
+     x2="290"
+     y2="240"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line24" />
+  <line
+     x1="270"
+     y1="220"
+     x2="310"
+     y2="220"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line25" />
+  <line
+     x1="230"
+     y1="170"
+     x2="230"
+     y2="190"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line26" />
+  <line
+     x1="170"
+     y1="180"
+     x2="230"
+     y2="180"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line27" />
+  <line
+     x1="170"
+     y1="110"
+     x2="170"
+     y2="180"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line28" />
+  <line
+     x1="150"
+     y1="110"
+     x2="170"
+     y2="110"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line29" />
+  <line
+     x1="150"
+     y1="70"
+     x2="230"
+     y2="70"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line30" />
+  <line
+     x1="230"
+     y1="70"
+     x2="230"
+     y2="120"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line31" />
+  <line
+     x1="290"
+     y1="300"
+     x2="290"
+     y2="302"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line32" />
+  <path
+     d="M 282,302 L 298,302 L 290,310 L 282,302 Z"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="path32" />
+  <line
+     x1="230"
+     y1="300"
+     x2="230"
+     y2="302"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line33" />
+  <path
+     d="M 222,302 L 238,302 L 230,310 L 222,302 Z"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="path33" />
+  <line
+     x1="360"
+     y1="410"
+     x2="360"
+     y2="427"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line34" />
+  <line
+     x1="360"
+     y1="453"
+     x2="360"
+     y2="460"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line35" />
+  <line
+     x1="320"
+     y1="440"
+     x2="346"
+     y2="440"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line36" />
+  <line
+     x1="345.5"
+     y1="432"
+     x2="345.5"
+     y2="448"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:3"
+     id="line37" />
+  <line
+     x1="360"
+     y1="427"
+     x2="345.5"
+     y2="436"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line38" />
+  <line
+     x1="345.5"
+     y1="444"
+     x2="360"
+     y2="453"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line39" />
+  <ellipse
+     cx="350"
+     cy="440"
+     rx="16"
+     ry="16"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse39" />
+  <path
+     d="M 352,447 L 356,445 L 357,452 L 351,448 L 353,447"
+     style="fill-opacity:1;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="path39" />
+  <line
+     x1="230"
+     y1="190"
+     x2="230"
+     y2="207"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line40" />
+  <line
+     x1="230"
+     y1="233"
+     x2="230"
+     y2="240"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line41" />
+  <line
+     x1="270"
+     y1="220"
+     x2="244"
+     y2="220"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line42" />
+  <line
+     x1="244.5"
+     y1="212"
+     x2="244.5"
+     y2="228"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:3"
+     id="line43" />
+  <line
+     x1="230"
+     y1="207"
+     x2="244.5"
+     y2="216"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line44" />
+  <line
+     x1="244.5"
+     y1="224"
+     x2="230"
+     y2="233"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line45" />
+  <ellipse
+     cx="240"
+     cy="220"
+     rx="16"
+     ry="16"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse45" />
+  <path
+     d="M 238,227 L 234,225 L 233,232 L 239,228 L 237,227"
+     style="fill-opacity:1;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="path45" />
+  <line
+     x1="300"
+     y1="460"
+     x2="300"
+     y2="465"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line46" />
+  <line
+     x1="300"
+     y1="505"
+     x2="300"
+     y2="510"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line47" />
+  <rect
+     x="292"
+     y="465"
+     width="16"
+     height="40"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="rect47" />
+  <text
+     x="286"
+     y="485"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 286, 485)"
+     id="text47">100 kΩ</text>
+  <line
+     x1="360"
+     y1="340"
+     x2="360"
+     y2="345"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line48" />
+  <line
+     x1="360"
+     y1="385"
+     x2="360"
+     y2="390"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line49" />
+  <rect
+     x="352"
+     y="345"
+     width="16"
+     height="40"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="rect49" />
+  <text
+     x="346"
+     y="365"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 346, 365)"
+     id="text49">10 kΩ</text>
+  <line
+     x1="220"
+     y1="440"
+     x2="225"
+     y2="440"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line50" />
+  <line
+     x1="265"
+     y1="440"
+     x2="270"
+     y2="440"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line51" />
+  <rect
+     x="225"
+     y="432"
+     width="40"
+     height="16"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="rect51" />
+  <text
+     x="245"
+     y="426"
+     style="font-family:Arial;font-size:11px;text-anchor:middle"
+     dominant-baseline="baseline"
+     transform="rotate(0, 245, 426)"
+     id="text51">1 kΩ</text>
+  <line
+     x1="310"
+     y1="220"
+     x2="315"
+     y2="220"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line52" />
+  <line
+     x1="355"
+     y1="220"
+     x2="360"
+     y2="220"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line53" />
+  <rect
+     x="315"
+     y="212"
+     width="40"
+     height="16"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="rect53" />
+  <text
+     x="335"
+     y="206"
+     style="font-family:Arial;font-size:11px;text-anchor:middle"
+     dominant-baseline="baseline"
+     transform="rotate(0, 335, 206)"
+     id="text53">1 kΩ</text>
+  <line
+     x1="290"
+     y1="240"
+     x2="290"
+     y2="245"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line54" />
+  <line
+     x1="290"
+     y1="285"
+     x2="290"
+     y2="290"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line55" />
+  <rect
+     x="282"
+     y="245"
+     width="16"
+     height="40"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="rect55" />
+  <text
+     x="276"
+     y="265"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 276, 265)"
+     id="text55">100 kΩ</text>
+  <line
+     x1="230"
+     y1="120"
+     x2="230"
+     y2="125"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line56" />
+  <line
+     x1="230"
+     y1="165"
+     x2="230"
+     y2="170"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line57" />
+  <rect
+     x="222"
+     y="125"
+     width="16"
+     height="40"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="rect57" />
+  <text
+     x="216"
+     y="145"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 216, 145)"
+     id="text57">10 kΩ</text>
+  <path
+     d="M 335,40 L 345,40 L 340,30 L 335,40 Z"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="path57" />
+  <text
+     x="334"
+     y="34"
+     style="font-family:Arial;font-size:12px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 334, 34)"
+     id="text58">+5V</text>
+  <line
+     x1="340"
+     y1="40"
+     x2="340"
+     y2="50"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line58" />
+  <line
+     x1="340"
+     y1="50"
+     x2="340"
+     y2="60"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line59" />
+  <line
+     x1="580"
+     y1="120"
+     x2="580"
+     y2="140"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line60" />
+  <line
+     x1="580"
+     y1="200"
+     x2="580"
+     y2="230"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line61" />
+  <path
+     d="M 575,110 L 585,110 L 580,100 L 575,110 Z"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="path61" />
+  <text
+     x="574"
+     y="104"
+     style="font-family:Arial;font-size:12px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 574, 104)"
+     id="text61">+5V</text>
+  <line
+     x1="580"
+     y1="110"
+     x2="580"
+     y2="120"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line62" />
+  <line
+     x1="340"
+     y1="100"
+     x2="340"
+     y2="122"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line63" />
+  <path
+     d="M 332,122 L 348,122 L 340,130 L 332,122 Z"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="path63" />
+  <line
+     x1="580"
+     y1="230"
+     x2="580"
+     y2="232"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line64" />
+  <path
+     d="M 572,232 L 588,232 L 580,240 L 572,232 Z"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="path64" />
+  <line
+     x1="260"
+     y1="100"
+     x2="340"
+     y2="100"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line65" />
+  <line
+     x1="260"
+     y1="60"
+     x2="260"
+     y2="100"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line66" />
+  <line
+     x1="150"
+     y1="60"
+     x2="260"
+     y2="60"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line67" />
+  <line
+     x1="150"
+     y1="50"
+     x2="340"
+     y2="50"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line68" />
+  <line
+     x1="340"
+     y1="50"
+     x2="340"
+     y2="60"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line69" />
+  <line
+     x1="340"
+     y1="50"
+     x2="340"
+     y2="71"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line70" />
+  <line
+     x1="340"
+     y1="79"
+     x2="340"
+     y2="100"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line71" />
+  <line
+     x1="326"
+     y1="71"
+     x2="354"
+     y2="71"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line72" />
+  <line
+     x1="326"
+     y1="79"
+     x2="354"
+     y2="79"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line73" />
+  <text
+     x="320"
+     y="75"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 320, 75)"
+     id="text73">4.7 µF</text>
+  <text
+     x="638"
+     y="200"
+     style="font-family:Arial;font-size:12px;text-anchor:start"
+     dominant-baseline="middle"
+     transform="rotate(0, 638, 200)"
+     id="text74">USB_GND</text>
+  <line
+     x1="580"
+     y1="200"
+     x2="627"
+     y2="200"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line74" />
+  <ellipse
+     cx="630"
+     cy="200"
+     rx="3"
+     ry="3"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse74" />
+  <text
+     x="638"
+     y="180"
+     style="font-family:Arial;font-size:12px;text-anchor:start"
+     dominant-baseline="middle"
+     transform="rotate(0, 638, 180)"
+     id="text75">USB_D+</text>
+  <line
+     x1="580"
+     y1="180"
+     x2="627"
+     y2="180"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line75" />
+  <ellipse
+     cx="630"
+     cy="180"
+     rx="3"
+     ry="3"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse75" />
+  <text
+     x="638"
+     y="160"
+     style="font-family:Arial;font-size:12px;text-anchor:start"
+     dominant-baseline="middle"
+     transform="rotate(0, 638, 160)"
+     id="text76">USB_D-</text>
+  <line
+     x1="580"
+     y1="160"
+     x2="627"
+     y2="160"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line76" />
+  <ellipse
+     cx="630"
+     cy="160"
+     rx="3"
+     ry="3"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse76" />
+  <text
+     x="638"
+     y="140"
+     style="font-family:Arial;font-size:12px;text-anchor:start"
+     dominant-baseline="middle"
+     transform="rotate(0, 638, 140)"
+     id="text77">USB_5V</text>
+  <line
+     x1="580"
+     y1="140"
+     x2="627"
+     y2="140"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line77" />
+  <ellipse
+     cx="630"
+     cy="140"
+     rx="3"
+     ry="3"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse77" />
+  <text
+     x="85"
+     y="30"
+     style="font-family:Arial;font-size:11px;text-anchor:middle"
+     dominant-baseline="middle"
+     transform="rotate(0, 85, 30)"
+     id="text78">XIAO ESP32C6</text>
+  <rect
+     x="35"
+     y="40"
+     width="100"
+     height="80"
+     style="fill-opacity:0;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="rect78" />
+  <line
+     x1="20"
+     y1="50"
+     x2="35"
+     y2="50"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line78" />
+  <text
+     x="39"
+     y="50"
+     style="font-family:Arial;font-size:11px;text-anchor:start"
+     dominant-baseline="middle"
+     transform="rotate(0, 39, 50)"
+     id="text79">GPIO0</text>
+  <line
+     x1="135"
+     y1="50"
+     x2="150"
+     y2="50"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line79" />
+  <text
+     x="131"
+     y="50"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 131, 50)"
+     id="text80">VBUS</text>
+  <line
+     x1="20"
+     y1="60"
+     x2="35"
+     y2="60"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line80" />
+  <text
+     x="39"
+     y="60"
+     style="font-family:Arial;font-size:11px;text-anchor:start"
+     dominant-baseline="middle"
+     transform="rotate(0, 39, 60)"
+     id="text81">GPIO1</text>
+  <line
+     x1="135"
+     y1="60"
+     x2="150"
+     y2="60"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line81" />
+  <text
+     x="131"
+     y="60"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 131, 60)"
+     id="text82">GND</text>
+  <line
+     x1="20"
+     y1="70"
+     x2="35"
+     y2="70"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line82" />
+  <text
+     x="39"
+     y="70"
+     style="font-family:Arial;font-size:11px;text-anchor:start"
+     dominant-baseline="middle"
+     transform="rotate(0, 39, 70)"
+     id="text83">GPIO2</text>
+  <line
+     x1="135"
+     y1="70"
+     x2="150"
+     y2="70"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line83" />
+  <text
+     x="131"
+     y="70"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 131, 70)"
+     id="text84">3V3-OUT</text>
+  <line
+     x1="20"
+     y1="80"
+     x2="35"
+     y2="80"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line84" />
+  <text
+     x="39"
+     y="80"
+     style="font-family:Arial;font-size:11px;text-anchor:start"
+     dominant-baseline="middle"
+     transform="rotate(0, 39, 80)"
+     id="text85">GPIO21</text>
+  <line
+     x1="135"
+     y1="80"
+     x2="150"
+     y2="80"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line85" />
+  <text
+     x="131"
+     y="80"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 131, 80)"
+     id="text86">GPIO18</text>
+  <line
+     x1="20"
+     y1="90"
+     x2="35"
+     y2="90"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line86" />
+  <text
+     x="39"
+     y="90"
+     style="font-family:Arial;font-size:11px;text-anchor:start"
+     dominant-baseline="middle"
+     transform="rotate(0, 39, 90)"
+     id="text87">GPIO22</text>
+  <line
+     x1="135"
+     y1="90"
+     x2="150"
+     y2="90"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line87" />
+  <text
+     x="131"
+     y="90"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 131, 90)"
+     id="text88">GPIO20</text>
+  <line
+     x1="20"
+     y1="100"
+     x2="35"
+     y2="100"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line88" />
+  <text
+     x="39"
+     y="100"
+     style="font-family:Arial;font-size:11px;text-anchor:start"
+     dominant-baseline="middle"
+     transform="rotate(0, 39, 100)"
+     id="text89">GPIO23</text>
+  <line
+     x1="135"
+     y1="100"
+     x2="150"
+     y2="100"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line89" />
+  <text
+     x="131"
+     y="100"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 131, 100)"
+     id="text90">GPIO19</text>
+  <line
+     x1="20"
+     y1="110"
+     x2="35"
+     y2="110"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line90" />
+  <text
+     x="39"
+     y="110"
+     style="font-family:Arial;font-size:11px;text-anchor:start"
+     dominant-baseline="middle"
+     transform="rotate(0, 39, 110)"
+     id="text91">GPIO16</text>
+  <line
+     x1="135"
+     y1="110"
+     x2="150"
+     y2="110"
+     style="stroke:rgb(0, 0, 0);stroke-linecap:square;stroke-width:2"
+     id="line91" />
+  <text
+     x="131"
+     y="110"
+     style="font-family:Arial;font-size:11px;text-anchor:end"
+     dominant-baseline="middle"
+     transform="rotate(0, 131, 110)"
+     id="text92">GPIO17</text>
+  <ellipse
+     cx="360"
+     cy="400"
+     rx="2"
+     ry="2"
+     style="fill-opacity:1;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse92" />
+  <ellipse
+     cx="300"
+     cy="440"
+     rx="2"
+     ry="2"
+     style="fill-opacity:1;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse93" />
+  <ellipse
+     cx="290"
+     cy="220"
+     rx="2"
+     ry="2"
+     style="fill-opacity:1;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse94" />
+  <ellipse
+     cx="230"
+     cy="180"
+     rx="2"
+     ry="2"
+     style="fill-opacity:1;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse95" />
+  <ellipse
+     cx="340"
+     cy="50"
+     rx="2"
+     ry="2"
+     style="fill-opacity:1;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse96" />
+  <ellipse
+     cx="340"
+     cy="100"
+     rx="2"
+     ry="2"
+     style="fill-opacity:1;fill:rgb(0, 0, 0);stroke:rgb(0, 0, 0);stroke-width:2"
+     id="ellipse97" />
+  <text
+     x="211.88934"
+     y="223.86998"
+     style="font-size:11px;font-family:Arial;text-anchor:end"
+     dominant-baseline="middle"
+     id="text55-6">BC847</text>
+  <text
+     x="406.69757"
+     y="442.32187"
+     style="font-size:11px;font-family:Arial;text-anchor:end"
+     dominant-baseline="middle"
+     id="text55-6-5">BC847</text>
+</svg>

--- a/src/docs/devices/Remko-RKL-355-Eco/config.yaml
+++ b/src/docs/devices/Remko-RKL-355-Eco/config.yaml
@@ -1,0 +1,66 @@
+esphome:
+  name: remko-rkl-355-eco
+  friendly_name: Remko RKL 355 Eco
+
+esp32:
+  variant: ESP32C6
+  flash_size: 4MB
+  framework:
+    type: esp-idf
+
+wifi:
+  ap:
+
+uart:
+  - baud_rate: 9600
+    rx_pin:
+      number: 17
+      inverted: true
+    tx_pin:
+      number: 16
+      inverted: true
+    id: uart_1
+
+status_led:
+  pin: GPIO15
+
+tuya:
+  uart_id: uart_1
+  id: tuya_1
+
+climate:
+  - platform: tuya
+    name: Remko
+    id: climate_tuya_1
+    supports_heat: false
+    supports_cool: true
+    switch_datapoint: 1
+    target_temperature_datapoint: 2
+    current_temperature_datapoint: 3
+    active_state:
+      datapoint: 4
+      cooling_value: 0
+      drying_value: 1
+      fanonly_value: 2
+    fan_mode:
+      datapoint: 5
+      low_value: 0
+      medium_value: 1
+      high_value: 2
+    swing_mode:
+      vertical_datapoint: 0x11
+    visual:
+      max_temperature: 32°C
+      min_temperature: 16°C
+      temperature_step: 1°C
+    temperature_multiplier: 1
+
+switch:
+  - platform: tuya
+    name: Remko Night Mode
+    switch_datapoint: 0x10
+    id: switch_tuya_1
+  - platform: tuya
+    name: Remko UVC
+    switch_datapoint: 0x12
+    id: switch_tuya_2

--- a/src/docs/devices/Remko-RKL-355-Eco/index.md
+++ b/src/docs/devices/Remko-RKL-355-Eco/index.md
@@ -1,0 +1,38 @@
+---
+title: "Remko RKL 355 Eco"
+date-published: 2026-07-12
+type: misc
+standard: eu
+difficulty: 4
+---
+
+The Remko RKL 355 Eco is a mono-block air conditioning unit. Remko added a port
+that looks like a USB port and allows connecting a separately sold Wi-Fi stick.
+The original Wi-Fi stick works only with the manufacturer's web service. It
+doesn't have any additional local control capabilities. The connection to the
+manufacturer's web service was quite unstable during some tests.
+
+Remko decided to use a physical USB A connector. But instead of USB, they use a
+normal serial protocol with 5V TTL levels. The serial settings are 9600 8N1. The
+protocol is Tuya compatible.
+
+## Hardware
+
+The original stick uses an ESP32. So in theory, it could be re-flashed. But it's
+quite expensive and I didn't want to trace all pins. Therefore I used a XIAO
+ESP32C6 board, two BC847 transistors and a few resistors as a replacement.
+
+![Circuit](circuit.svg "Circuit for the home-built Remko ESPHome integration")
+
+Any other ESP32 with a hardware serial interface should work too. For the
+transistors, any small signal NPN transistor should work. A well-known THT
+alternative for the BC847 is the BC547.
+
+## Configuration
+
+Only the parts necessary for the hardware. Don't forget to add your Wi-Fi
+credentials under the existing `wifi:` block, plus your own `api:` and `ota:`
+sections.
+
+```yaml file=config.yaml
+```


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Add a Remko RKL 355 ECO AC unit.


## Type of changes

- [X] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [X] Adding a new device adds a single device only — one device per pull request.
- [X] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [X] The first `file=` fence on the page references `config.yaml`.
- [X] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [X] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [X] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [X] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
