### PR TITLE
Add Tuya 8-Zone Sprinkler Controller TY-W-8L (BK7231N/CBU)

### DIFF
--- a/src/docs/devices/tuya-8zone-sprinkler-ty-w-8l/config.yaml
+++ b/src/docs/devices/tuya-8zone-sprinkler-ty-w-8l/config.yaml
@@ -1,0 +1,494 @@
+esphome:
+  name: tuya-sprinkler-8z
+  friendly_name: Tuya Sprinkler 8Z
+  on_boot:
+    priority: 800
+    then:
+      - delay: 500ms
+      - output.turn_off: led_1
+      - output.turn_off: led_2
+      - output.turn_off: led_3
+      - output.turn_off: led_4
+      - output.turn_off: led_5
+      - output.turn_off: led_6
+      - output.turn_off: led_7
+      - output.turn_off: led_8
+      - switch.turn_off: valve_1
+      - switch.turn_off: valve_2
+      - switch.turn_off: valve_3
+      - switch.turn_off: valve_4
+      - switch.turn_off: valve_5
+      - switch.turn_off: valve_6
+      - switch.turn_off: valve_7
+      - switch.turn_off: valve_8
+
+bk72xx:
+  board: cbu
+
+logger:
+  level: DEBUG
+
+api:
+
+ota:
+  - platform: esphome
+
+wifi:
+  ap:
+    ssid: "Sprinkler-8Z Fallback"
+    password: "12345678"
+
+captive_portal:
+web_server:
+  port: 80
+
+status_led:
+  pin:
+    number: P28
+    inverted: false
+
+sn74hc595:
+  - id: led_sn74hc595
+    data_pin: P9
+    clock_pin: P15
+    latch_pin: P17
+  - id: valve_sn74hc595
+    data_pin: P16
+    clock_pin: P22
+    latch_pin: P20
+
+output:
+  - platform: gpio
+    id: buzzer
+    pin:
+      number: P14
+      inverted: false
+  - platform: gpio
+    id: led_1
+    pin:
+      sn74hc595: led_sn74hc595
+      number: 0
+      inverted: true
+  - platform: gpio
+    id: led_2
+    pin:
+      sn74hc595: led_sn74hc595
+      number: 1
+      inverted: true
+  - platform: gpio
+    id: led_3
+    pin:
+      sn74hc595: led_sn74hc595
+      number: 2
+      inverted: true
+  - platform: gpio
+    id: led_4
+    pin:
+      sn74hc595: led_sn74hc595
+      number: 3
+      inverted: true
+  - platform: gpio
+    id: led_5
+    pin:
+      sn74hc595: led_sn74hc595
+      number: 4
+      inverted: true
+  - platform: gpio
+    id: led_6
+    pin:
+      sn74hc595: led_sn74hc595
+      number: 5
+      inverted: true
+  - platform: gpio
+    id: led_7
+    pin:
+      sn74hc595: led_sn74hc595
+      number: 6
+      inverted: true
+  - platform: gpio
+    id: led_8
+    pin:
+      sn74hc595: led_sn74hc595
+      number: 7
+      inverted: true
+
+switch:
+  - platform: gpio
+    id: valve_1
+    name: "Valve 1"
+    pin:
+      sn74hc595: valve_sn74hc595
+      number: 0
+      inverted: false
+    on_turn_on:
+      then:
+        - lambda: if (id(selected_zone) != 0) id(led_1)->turn_on();
+    on_turn_off:
+      then:
+        - lambda: if (id(selected_zone) != 1) id(led_1)->turn_off();
+  - platform: gpio
+    id: valve_2
+    name: "Valve 2"
+    pin:
+      sn74hc595: valve_sn74hc595
+      number: 1
+      inverted: false
+    on_turn_on:
+      then:
+        - lambda: if (id(selected_zone) != 1) id(led_2)->turn_on();
+    on_turn_off:
+      then:
+        - lambda: if (id(selected_zone) != 2) id(led_2)->turn_off();
+  - platform: gpio
+    id: valve_3
+    name: "Valve 3"
+    pin:
+      sn74hc595: valve_sn74hc595
+      number: 2
+      inverted: false
+    on_turn_on:
+      then:
+        - lambda: if (id(selected_zone) != 2) id(led_3)->turn_on();
+    on_turn_off:
+      then:
+        - lambda: if (id(selected_zone) != 3) id(led_3)->turn_off();
+  - platform: gpio
+    id: valve_4
+    name: "Valve 4"
+    pin:
+      sn74hc595: valve_sn74hc595
+      number: 3
+      inverted: false
+    on_turn_on:
+      then:
+        - lambda: if (id(selected_zone) != 3) id(led_4)->turn_on();
+    on_turn_off:
+      then:
+        - lambda: if (id(selected_zone) != 4) id(led_4)->turn_off();
+  - platform: gpio
+    id: valve_5
+    name: "Valve 5"
+    pin:
+      sn74hc595: valve_sn74hc595
+      number: 4
+      inverted: false
+    on_turn_on:
+      then:
+        - lambda: if (id(selected_zone) != 4) id(led_5)->turn_on();
+    on_turn_off:
+      then:
+        - lambda: if (id(selected_zone) != 5) id(led_5)->turn_off();
+  - platform: gpio
+    id: valve_6
+    name: "Valve 6"
+    pin:
+      sn74hc595: valve_sn74hc595
+      number: 5
+      inverted: false
+    on_turn_on:
+      then:
+        - lambda: if (id(selected_zone) != 5) id(led_6)->turn_on();
+    on_turn_off:
+      then:
+        - lambda: if (id(selected_zone) != 6) id(led_6)->turn_off();
+  - platform: gpio
+    id: valve_7
+    name: "Valve 7"
+    pin:
+      sn74hc595: valve_sn74hc595
+      number: 6
+      inverted: false
+    on_turn_on:
+      then:
+        - lambda: if (id(selected_zone) != 6) id(led_7)->turn_on();
+    on_turn_off:
+      then:
+        - lambda: if (id(selected_zone) != 7) id(led_7)->turn_off();
+  - platform: gpio
+    id: valve_8
+    name: "Valve 8"
+    pin:
+      sn74hc595: valve_sn74hc595
+      number: 7
+      inverted: false
+    on_turn_on:
+      then:
+        - lambda: if (id(selected_zone) != 7) id(led_8)->turn_on();
+    on_turn_off:
+      then:
+        - lambda: if (id(selected_zone) != 8) id(led_8)->turn_off();
+
+globals:
+  - id: selected_zone
+    type: int
+    initial_value: "-1"
+  - id: all_zones_mode
+    type: int
+    initial_value: "0"
+  - id: last_button_time
+    type: uint32_t
+    initial_value: "0"
+
+interval:
+  - interval: 500ms
+    then:
+      - lambda: |
+          uint32_t now = millis();
+          if ((id(selected_zone) >= 0 || id(all_zones_mode) != 0) && (now - id(last_button_time)) > 8000) {
+            id(cancel_selection)->execute();
+            return;
+          }
+          
+          if (id(selected_zone) >= 0 && id(all_zones_mode) == 0) {
+            static bool blink_state = false;
+            blink_state = !blink_state;
+            auto leds = {id(led_1), id(led_2), id(led_3), id(led_4), id(led_5), id(led_6), id(led_7), id(led_8)};
+            int i = 0;
+            for (auto led : leds) {
+              if (i == id(selected_zone)) {
+                if (blink_state) led->turn_on();
+                else led->turn_off();
+              } else {
+                auto valve_id = id(irrigador).valve_switch(i);
+                if (valve_id != nullptr && valve_id->state) {
+                  led->turn_on();
+                } else {
+                  led->turn_off();
+                }
+              }
+              i++;
+            }
+          } else if (id(all_zones_mode) != 0) {
+            static bool blink_all = false;
+            blink_all = !blink_all;
+            auto leds = {id(led_1), id(led_2), id(led_3), id(led_4), id(led_5), id(led_6), id(led_7), id(led_8)};
+            for (auto led : leds) {
+              if (blink_all) led->turn_on();
+              else led->turn_off();
+            }
+          }
+
+script:
+  - id: beep_3_times
+    then:
+      - output.turn_on: buzzer
+      - delay: 80ms
+      - output.turn_off: buzzer
+      - delay: 80ms
+      - output.turn_on: buzzer
+      - delay: 80ms
+      - output.turn_off: buzzer
+      - delay: 80ms
+      - output.turn_on: buzzer
+      - delay: 80ms
+      - output.turn_off: buzzer
+
+  - id: cancel_selection
+    then:
+      - lambda: |
+          id(selected_zone) = -1;
+          id(all_zones_mode) = 0;
+          auto leds = {id(led_1), id(led_2), id(led_3), id(led_4), id(led_5), id(led_6), id(led_7), id(led_8)};
+          int i = 0;
+          for (auto led : leds) {
+            auto valve_id = id(irrigador).valve_switch(i);
+            if (valve_id != nullptr && valve_id->state) {
+              led->turn_on();
+            } else {
+              led->turn_off();
+            }
+            i++;
+          }
+
+  - id: activate_zone
+    parameters:
+      zone: int
+    then:
+      - lambda: |
+          for (size_t i = 0; i < 8; i++) {
+            if (i == zone) {
+              id(irrigador).enable_switch(i)->turn_on();
+            } else {
+              id(irrigador).enable_switch(i)->turn_off();
+            }
+          }
+          id(irrigador).resume_or_start_full_cycle();
+          id(selected_zone) = -1;
+          id(all_zones_mode) = 0;
+
+  - id: activate_all_zones
+    then:
+      - lambda: |
+          for (size_t i = 0; i < 8; i++) {
+            id(irrigador).enable_switch(i)->turn_on();
+          }
+          id(irrigador).resume_or_start_full_cycle();
+          id(all_zones_mode) = 0;
+          id(selected_zone) = -1;
+
+  - id: stop_all_zones
+    then:
+      - lambda: |
+          id(irrigador).shutdown();
+          id(all_zones_mode) = 0;
+          id(selected_zone) = -1;
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: P6
+      inverted: true
+    name: "Button UP (P6)"
+    internal: true
+    on_multi_click:
+      - timing:
+          - ON for at least 4s
+        then:
+          - output.turn_on: buzzer
+          - delay: 100ms
+          - output.turn_off: buzzer
+          - lambda: |
+              id(all_zones_mode) = 1;
+              id(selected_zone) = -1;
+              id(last_button_time) = millis();
+      - timing:
+          - ON for at most 3999ms
+        then:
+          - output.turn_on: buzzer
+          - delay: 100ms
+          - output.turn_off: buzzer
+          - lambda: |
+              int current = id(selected_zone);
+              if (current < 0) {
+                auto av = id(irrigador).active_valve();
+                current = av.has_value() ? av.value() : -1;
+              }
+              int next = (current + 1) % 8;
+              id(selected_zone) = next;
+              id(all_zones_mode) = 0;
+              id(last_button_time) = millis();
+
+  - platform: gpio
+    pin:
+      number: P7
+      inverted: true
+    name: "Button DOWN (P7)"
+    internal: true
+    on_multi_click:
+      - timing:
+          - ON for at least 4s
+        then:
+          - output.turn_on: buzzer
+          - delay: 100ms
+          - output.turn_off: buzzer
+          - lambda: |
+              id(all_zones_mode) = 2;
+              id(selected_zone) = -1;
+              id(last_button_time) = millis();
+      - timing:
+          - ON for at most 3999ms
+        then:
+          - output.turn_on: buzzer
+          - delay: 100ms
+          - output.turn_off: buzzer
+          - lambda: |
+              int current = id(selected_zone);
+              if (current < 0) {
+                auto av = id(irrigador).active_valve();
+                current = av.has_value() ? av.value() : 8;
+              }
+              int prev = (current + 7) % 8;
+              id(selected_zone) = prev;
+              id(all_zones_mode) = 0;
+              id(last_button_time) = millis();
+
+  - platform: gpio
+    pin:
+      number: P8
+      inverted: true
+    name: "Button SET (P8)"
+    internal: true
+    on_press:
+      then:
+        - output.turn_on: buzzer
+        - delay: 100ms
+        - output.turn_off: buzzer
+        - lambda: |
+            if (id(all_zones_mode) == 1) {
+              id(activate_all_zones)->execute();
+              id(beep_3_times)->execute();
+            } else if (id(all_zones_mode) == 2) {
+              id(stop_all_zones)->execute();
+              id(beep_3_times)->execute();
+            } else if (id(selected_zone) >= 0) {
+              auto current = id(irrigador).active_valve();
+              if (current.has_value() && current.value() == id(selected_zone)) {
+                id(irrigador).shutdown();
+                id(selected_zone) = -1;
+              } else {
+                id(activate_zone)->execute(id(selected_zone));
+              }
+            }
+
+sprinkler:
+  - id: irrigador
+    main_switch: "Irrigation"
+    auto_advance_switch: "Auto Advance"
+    valve_overlap: 5s
+    valves:
+      - valve_switch: "Zone 1"
+        enable_switch: "Enable Zone 1"
+        run_duration_number:
+          name: "Zone 1 Duration"
+          initial_value: 5
+          unit_of_measurement: min
+        valve_switch_id: valve_1
+      - valve_switch: "Zone 2"
+        enable_switch: "Enable Zone 2"
+        run_duration_number:
+          name: "Zone 2 Duration"
+          initial_value: 5
+          unit_of_measurement: min
+        valve_switch_id: valve_2
+      - valve_switch: "Zone 3"
+        enable_switch: "Enable Zone 3"
+        run_duration_number:
+          name: "Zone 3 Duration"
+          initial_value: 5
+          unit_of_measurement: min
+        valve_switch_id: valve_3
+      - valve_switch: "Zone 4"
+        enable_switch: "Enable Zone 4"
+        run_duration_number:
+          name: "Zone 4 Duration"
+          initial_value: 5
+          unit_of_measurement: min
+        valve_switch_id: valve_4
+      - valve_switch: "Zone 5"
+        enable_switch: "Enable Zone 5"
+        run_duration_number:
+          name: "Zone 5 Duration"
+          initial_value: 5
+          unit_of_measurement: min
+        valve_switch_id: valve_5
+      - valve_switch: "Zone 6"
+        enable_switch: "Enable Zone 6"
+        run_duration_number:
+          name: "Zone 6 Duration"
+          initial_value: 5
+          unit_of_measurement: min
+        valve_switch_id: valve_6
+      - valve_switch: "Zone 7"
+        enable_switch: "Enable Zone 7"
+        run_duration_number:
+          name: "Zone 7 Duration"
+          initial_value: 5
+          unit_of_measurement: min
+        valve_switch_id: valve_7
+      - valve_switch: "Zone 8"
+        enable_switch: "Enable Zone 8"
+        run_duration_number:
+          name: "Zone 8 Duration"
+          initial_value: 5
+          unit_of_measurement: min
+        valve_switch_id: valve_8

--- a/src/docs/devices/tuya-8zone-sprinkler-ty-w-8l/config.yaml
+++ b/src/docs/devices/tuya-8zone-sprinkler-ty-w-8l/config.yaml
@@ -28,19 +28,8 @@ bk72xx:
 logger:
   level: DEBUG
 
-api:
-
-ota:
-  - platform: esphome
-
 wifi:
   ap:
-    ssid: "Sprinkler-8Z Fallback"
-    password: "12345678"
-
-captive_portal:
-web_server:
-  port: 80
 
 status_led:
   pin:
@@ -234,15 +223,17 @@ interval:
     then:
       - lambda: |
           uint32_t now = millis();
-          if ((id(selected_zone) >= 0 || id(all_zones_mode) != 0) && (now - id(last_button_time)) > 8000) {
+          if ((id(selected_zone) >= 0 || id(all_zones_mode) != 0) &&
+              (now - id(last_button_time)) > 8000) {
             id(cancel_selection)->execute();
             return;
           }
-          
+
           if (id(selected_zone) >= 0 && id(all_zones_mode) == 0) {
             static bool blink_state = false;
             blink_state = !blink_state;
-            auto leds = {id(led_1), id(led_2), id(led_3), id(led_4), id(led_5), id(led_6), id(led_7), id(led_8)};
+            auto leds = {id(led_1), id(led_2), id(led_3), id(led_4),
+                         id(led_5), id(led_6), id(led_7), id(led_8)};
             int i = 0;
             for (auto led : leds) {
               if (i == id(selected_zone)) {
@@ -261,7 +252,8 @@ interval:
           } else if (id(all_zones_mode) != 0) {
             static bool blink_all = false;
             blink_all = !blink_all;
-            auto leds = {id(led_1), id(led_2), id(led_3), id(led_4), id(led_5), id(led_6), id(led_7), id(led_8)};
+            auto leds = {id(led_1), id(led_2), id(led_3), id(led_4),
+                         id(led_5), id(led_6), id(led_7), id(led_8)};
             for (auto led : leds) {
               if (blink_all) led->turn_on();
               else led->turn_off();
@@ -288,7 +280,8 @@ script:
       - lambda: |
           id(selected_zone) = -1;
           id(all_zones_mode) = 0;
-          auto leds = {id(led_1), id(led_2), id(led_3), id(led_4), id(led_5), id(led_6), id(led_7), id(led_8)};
+          auto leds = {id(led_1), id(led_2), id(led_3), id(led_4),
+                       id(led_5), id(led_6), id(led_7), id(led_8)};
           int i = 0;
           for (auto led : leds) {
             auto valve_id = id(irrigador).valve_switch(i);

--- a/src/docs/devices/tuya-8zone-sprinkler-ty-w-8l/index.md
+++ b/src/docs/devices/tuya-8zone-sprinkler-ty-w-8l/index.md
@@ -8,7 +8,9 @@ project-url: https://github.com/gnacho/esphome-tuya-8zone-valve
 difficulty: 4
 ---
 
-Generic Tuya 8-zone irrigation controller with Beken BK7231N (CBU module). PCB model TY-W-8L-AC-DZAK. Uses two independent 74HC595 shift registers for LEDs and valves.
+Generic Tuya 8-zone irrigation controller with Beken BK7231N (CBU module).
+PCB model TY-W-8L-AC-DZAK. Uses two independent 74HC595 shift registers for
+LEDs and valves.
 
 ## Hardware
 
@@ -24,11 +26,13 @@ Generic Tuya 8-zone irrigation controller with Beken BK7231N (CBU module). PCB m
 
 ## Installation
 
-The BK7231N is flashed via UART with [ltchiptool](https://github.com/libretiny-eu/ltchiptool). No soldering required — dupont cables and a steady hand are enough.
+The BK7231N is flashed via UART with
+[ltchiptool](https://github.com/libretiny-eu/ltchiptool). No soldering required
+— dupont cables and a steady hand are enough.
 
 ### Connections (3.3V USB-TTL adapter)
 
-```
+```text
   USB-TTL Adapter            TY-W-8L-AC-DZAK Board
   ───────────────            ─────────────────────
        3.3V  ───────────────────►  3.3V
@@ -37,17 +41,19 @@ The BK7231N is flashed via UART with [ltchiptool](https://github.com/libretiny-e
          RX  ◄───────────────────  TX
 ```
 
-**CRITICAL WARNING**: **NEVER connect 3.3V from USB adapter and 24VAC at the same time**. You can damage the board.
+**CRITICAL WARNING**: **NEVER connect 3.3V from USB adapter and 24VAC at the
+same time**. You can damage the board.
 
-**Option A: 3.3V only (preferable if it works)**
+### Option A: 3.3V only (preferable if it works)
 
-Connect all 4 dupont cables (3.3V, GND, TX, RX) as shown above. Try flashing first with this setup.
+Connect all 4 dupont cables (3.3V, GND, TX, RX) as shown above. Try flashing
+first with this setup.
 
-**Option B: With 24VAC (if 3.3V doesn't work)**
+### Option B: With 24VAC (if 3.3V doesn't work)
 
 If Option A fails, disconnect the 3.3V cable and use the 24VAC transformer:
 
-```
+```text
   USB-TTL Adapter            TY-W-8L-AC-DZAK Board
   ───────────────            ─────────────────────
         GND  ───────────────────►  GND
@@ -59,7 +65,8 @@ If Option A fails, disconnect the 3.3V cable and use the 24VAC transformer:
        24VAC ───────────────────►  AC IN (terminals)
 ```
 
-In Option B, **DO NOT connect the 3.3V cable from the USB adapter**. Only GND, TX and RX. The board generates its own 3.3V internally from the 24VAC.
+In Option B, **DO NOT connect the 3.3V cable from the USB adapter**. Only GND,
+TX and RX. The board generates its own 3.3V internally from the 24VAC.
 
 ### Flashing process
 
@@ -87,7 +94,8 @@ ltchiptool flash read bk7231n backup_original.bin
 - **DOWN**: selects the previous zone (LED blinks)
 - **SET**: confirms selection and activates the zone (LED stays solid)
 
-If you don't press anything for **8 seconds**, the selection is automatically cancelled.
+If you don't press anything for **8 seconds**, the selection is automatically
+cancelled.
 
 ### Activate a single zone
 
@@ -112,4 +120,5 @@ If you don't press anything for **8 seconds**, the selection is automatically ca
 
 ## Project repository
 
-Full documentation, compiled firmware binaries, and source code available at [github.com/gnacho/esphome-tuya-8zone-valve](https://github.com/gnacho/esphome-tuya-8zone-valve).
+Full documentation, compiled firmware binaries, and source code available at
+[github.com/gnacho/esphome-tuya-8zone-valve](https://github.com/gnacho/esphome-tuya-8zone-valve).

--- a/src/docs/devices/tuya-8zone-sprinkler-ty-w-8l/index.md
+++ b/src/docs/devices/tuya-8zone-sprinkler-ty-w-8l/index.md
@@ -1,0 +1,115 @@
+---
+title: Tuya 8-Zone Sprinkler Controller TY-W-8L (BK7231N/CBU)
+date-published: 2026-07-15
+type: misc
+standard: global
+board: bk72xx
+project-url: https://github.com/gnacho/esphome-tuya-8zone-valve
+difficulty: 4
+---
+
+Generic Tuya 8-zone irrigation controller with Beken BK7231N (CBU module). PCB model TY-W-8L-AC-DZAK. Uses two independent 74HC595 shift registers for LEDs and valves.
+
+## Hardware
+
+- **SoC**: Beken BK7231N (CBU module)
+- **PCB**: TY-W-8L-AC-DZAK rev 24.9.19
+- **Shift registers**: 2x 74HC595 independent (not cascaded)
+  - LED SR (U2): data P9, clock P15, latch P17
+  - Valve SR (U3): data P16, clock P22, latch P20
+- **Buzzer**: P14
+- **WiFi LED**: P28
+- **Touch buttons**: UP (P6), DOWN (P7), SET (P8)
+- **Power**: 24 VAC
+
+## Installation
+
+The BK7231N is flashed via UART with [ltchiptool](https://github.com/libretiny-eu/ltchiptool). No soldering required — dupont cables and a steady hand are enough.
+
+### Connections (3.3V USB-TTL adapter)
+
+```
+  USB-TTL Adapter            TY-W-8L-AC-DZAK Board
+  ───────────────            ─────────────────────
+       3.3V  ───────────────────►  3.3V
+        GND  ───────────────────►  GND
+         TX  ───────────────────►  RX
+         RX  ◄───────────────────  TX
+```
+
+**CRITICAL WARNING**: **NEVER connect 3.3V from USB adapter and 24VAC at the same time**. You can damage the board.
+
+**Option A: 3.3V only (preferable if it works)**
+
+Connect all 4 dupont cables (3.3V, GND, TX, RX) as shown above. Try flashing first with this setup.
+
+**Option B: With 24VAC (if 3.3V doesn't work)**
+
+If Option A fails, disconnect the 3.3V cable and use the 24VAC transformer:
+
+```
+  USB-TTL Adapter            TY-W-8L-AC-DZAK Board
+  ───────────────            ─────────────────────
+        GND  ───────────────────►  GND
+         TX  ───────────────────►  RX
+         RX  ◄───────────────────  TX
+
+  24VAC Transformer          TY-W-8L-AC-DZAK Board
+  ─────────────────          ─────────────────────
+       24VAC ───────────────────►  AC IN (terminals)
+```
+
+In Option B, **DO NOT connect the 3.3V cable from the USB adapter**. Only GND, TX and RX. The board generates its own 3.3V internally from the 24VAC.
+
+### Flashing process
+
+1. Connect the dupont cables to the board
+2. Power the board (3.3V or 24VAC as described above)
+3. Enter download mode: briefly touch RST to GND (a couple of quick taps)
+4. Immediately run the flash command:
+
+```bash
+pip install ltchiptool
+ltchiptool flash write bk7231n config.yaml
+```
+
+### Backup original firmware (recommended)
+
+```bash
+ltchiptool flash read bk7231n backup_original.bin
+```
+
+## Button usage
+
+### Navigation and zone selection
+
+- **UP**: selects the next zone (LED blinks)
+- **DOWN**: selects the previous zone (LED blinks)
+- **SET**: confirms selection and activates the zone (LED stays solid)
+
+If you don't press anything for **8 seconds**, the selection is automatically cancelled.
+
+### Activate a single zone
+
+1. Press UP or DOWN until the desired zone LED blinks
+2. Press SET → the zone activates (solid LED)
+3. To stop it: navigate to that zone and press SET again
+
+### Activate all zones (full cycle)
+
+1. Hold **UP** for **4 seconds** until all LEDs blink
+2. Press SET → all 8 zones activate in full cycle (3 confirmation beeps)
+
+### Stop all irrigation
+
+1. Hold **DOWN** for **4 seconds** until all LEDs blink
+2. Press SET → all zones close (3 confirmation beeps)
+
+## Basic Configuration
+
+```yaml file=config.yaml
+```
+
+## Project repository
+
+Full documentation, compiled firmware binaries, and source code available at [github.com/gnacho/esphome-tuya-8zone-valve](https://github.com/gnacho/esphome-tuya-8zone-valve).


### PR DESCRIPTION
Adds documentation and ESPHome config for the Tuya TY-W-8L 8-zone sprinkler controller with Beken BK7231N SoC.

Features:
- Two independent 74HC595 shift registers (LEDs + valves)
- Smart button navigation with blinking LED feedback
- Long press for all-zones control (4s)
- 8-second timeout auto-cancel
- Buzzer confirmation on button press
- Full sprinkler component integration
- Detailed flashing instructions (no soldering required)

Project repo: https://github.com/gnacho/esphome-tuya-8zone-valve