### PR TITLE
Feat/pc191ha series4

### DIFF
--- a/src/docs/devices/Arlec-PC191HA-Series-4-Plug/config.yaml
+++ b/src/docs/devices/Arlec-PC191HA-Series-4-Plug/config.yaml
@@ -1,0 +1,64 @@
+bk72xx:
+  board: generic-bk7238-tuya
+  family: BK7238
+esphome:
+  name: pc191ha-gen4
+  name_add_mac_suffix: true
+
+wifi:
+  ap:
+
+button:
+  - platform: restart
+    name: Restart
+
+sensor:
+  - platform: bl0942
+    uart_id: uart_bus
+    current:
+      name: BL0942 Current
+    voltage:
+      name: BL0942 Voltage
+    power:
+      name: BL0942 Power
+      filters:
+        multiply: -1
+    energy:
+      name: BL0942 Energy
+    frequency:
+      name: BL0942 Frequency
+      accuracy_decimals: 2
+
+light:
+  - platform: status_led
+    id: light_status
+    pin: P8
+
+binary_sensor:
+  - platform: gpio
+    id: binary_switch_1
+    pin:
+      number: P24
+      inverted: true
+      mode: INPUT_PULLUP
+    on_press:
+      then:
+        - switch.toggle: switch_1
+
+switch:
+  - platform: gpio
+    id: switch_1
+    name: Relay 1
+    pin: P26
+    on_turn_on:
+      - light.turn_on: light_status
+    on_turn_off:
+      - light.turn_off: light_status
+    restore_mode: ALWAYS_ON
+
+uart: 
+  id: uart_bus
+  tx_pin: TX1
+  rx_pin: RX1
+  baud_rate: 4800
+  stop_bits: 1

--- a/src/docs/devices/Arlec-PC191HA-Series-4-Plug/config.yaml
+++ b/src/docs/devices/Arlec-PC191HA-Series-4-Plug/config.yaml
@@ -56,7 +56,7 @@ switch:
       - light.turn_off: light_status
     restore_mode: ALWAYS_ON
 
-uart: 
+uart:
   id: uart_bus
   tx_pin: TX1
   rx_pin: RX1

--- a/src/docs/devices/Arlec-PC191HA-Series-4-Plug/index.md
+++ b/src/docs/devices/Arlec-PC191HA-Series-4-Plug/index.md
@@ -15,7 +15,10 @@ Bunnings in Australia and New Zealand.
 These are available in White (PC191HA) or Black (PC191BKHA), and in 4-packs of White and Black - which are identical.  
 It is compact, easily fitting side-by-side in double wall sockets.
 
-The Arlec Grid Connect Smart Plug In Socket With Energy Meter uses a T1-2S module with BK7238 chip. They are not vulnerable to the cloudcutter exploit, and require soldering to remove the main PCB from the housing, and further soldering to remove the module from the PCB. Not for the faint of heart, but working with the DEV release of ESPHome 2026.08 as at July 2026. They use a BL0942 energy sensor that is connected via two UART pins only.
+The Arlec Grid Connect Smart Plug In Socket With Energy Meter uses a T1-2S module with BK7238 chip. They are not
+vulnerable to the cloudcutter exploit, and require soldering to remove the main PCB from the housing, and further
+soldering to remove the module from the PCB. Not for the faint of heart, but working with the DEV release of ESPHome
+2026.08 as at July 2026. They use a BL0942 energy sensor that is connected via two UART pins only.
 
 ## GPIO Pinout
 
@@ -29,13 +32,15 @@ The Arlec Grid Connect Smart Plug In Socket With Energy Meter uses a T1-2S modul
 
 ## Getting it up and running
 
-As with prior generations of the PC191HA, the case is ultrasonic-welded and will require a thin tool to pry it open. Some cosmetic damage is bound to occur.
-Once open, a reasonably powerful soldering it required to remove the main PCB from the power pins. Heat each side in turn and raise the PCB a little from each side.
+As with prior generations of the PC191HA, the case is ultrasonic-welded and will require a thin tool to pry it open. 
+Some cosmetic damage is bound to occur.
+Once open, a reasonably powerful soldering it required to remove the main PCB from the power pins. Heat each side in
+turn and raise the PCB a little from each side.
 Then the module can be removed from the board by way of desoldering wick.
 
 The module is labelled, connections to 3V3, GND, TX1 and RX1 are required. Crossover the UART pins to your TTL adaptor:
 
-| Pin Module | Pin TTL
+| Pin Module | Pin TTL |
 | -- | -- |
 |  TX1 | RX |
 | RX1 | TX |

--- a/src/docs/devices/Arlec-PC191HA-Series-4-Plug/index.md
+++ b/src/docs/devices/Arlec-PC191HA-Series-4-Plug/index.md
@@ -1,0 +1,48 @@
+---
+title: Arlec PC191HA Series 4
+date-published: 2026-06-16
+type: plug
+standard: au
+board: bk72xx
+made-for-esphome: false
+difficulty: 4
+---
+
+![Product Image](Arlec-PC191HA-Plug.jpg "Product Image")
+
+The Arlec PC191HA power plug is part of the [Grid Connect ecosystem](https://grid-connect.com.au/) and is sold at
+Bunnings in Australia and New Zealand.  
+These are available in White (PC191HA) or Black (PC191BKHA), and in 4-packs of White and Black - which are identical.  
+It is compact, easily fitting side-by-side in double wall sockets.
+
+The Arlec Grid Connect Smart Plug In Socket With Energy Meter uses a T1-2S module with BK7238 chip. They are not vulnerable to the cloudcutter exploit, and require soldering to remove the main PCB from the housing, and further soldering to remove the module from the PCB. Not for the faint of heart, but working with the DEV release of ESPHome 2026.08 as at July 2026. They use a BL0942 energy sensor that is connected via two UART pins only.
+
+## GPIO Pinout
+
+| Pin | Function                             |
+| --- | ------------------------------------ |
+| P8  | (P8) Status LED                      |
+| P10 | (RX1) BL0942 UART TX                 |
+| P11 | (TX1) BL0942 UART RX                 |
+| P24 | (P24) Button                         |
+| P26 | (P26) Relay                          |
+
+## Getting it up and running
+
+As with prior generations of the PC191HA, the case is ultrasonic-welded and will require a thin tool to pry it open. Some cosmetic damage is bound to occur.
+Once open, a reasonably powerful soldering it required to remove the main PCB from the power pins. Heat each side in turn and raise the PCB a little from each side.
+Then the module can be removed from the board by way of desoldering wick.
+
+The module is labelled, connections to 3V3, GND, TX1 and RX1 are required. Crossover the UART pins to your TTL adaptor:
+
+| Pin Module | Pin TTL
+| -- | -- |
+|  TX1 | RX |
+| RX1 | TX |
+
+Briefly touching CEN while your flasher is running will reset the chip and allow flash upload to begin.
+
+## Basic Config
+
+```yaml file=config.yaml
+```


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [x] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [ ] The first `file=` fence on the page references `config.yaml`.
- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
