### PR TITLE
Add MottramLabs MLP201193 ESP32 4-Channel Mains Power Sensor

### DIFF
--- a/src/docs/devices/Mottramlabs-MLP201193/config.yaml
+++ b/src/docs/devices/Mottramlabs-MLP201193/config.yaml
@@ -1,0 +1,123 @@
+esphome:
+  name: ct-power-monitor
+  friendly_name: "CT Power Monitor"
+
+esp32:
+  board: nodemcu-32s
+  framework:
+    type: esp-idf
+
+wifi:
+  power_save_mode: none
+  ap:
+
+captive_portal:
+
+logger:
+
+sensor:
+  # Raw ADC inputs (internal) -- attenuation 12dB for 0-3.3V range
+  # MLP201193: CH1=D34, CH2=D35, CH3=D36, CH4=D39
+  - platform: adc
+    pin: GPIO34
+    id: adc_ch1
+    attenuation: 12db
+    internal: true
+
+  - platform: adc
+    pin: GPIO35
+    id: adc_ch2
+    attenuation: 12db
+    internal: true
+
+  - platform: adc
+    pin: GPIO36
+    id: adc_ch3
+    attenuation: 12db
+    internal: true
+
+  - platform: adc
+    pin: GPIO39
+    id: adc_ch4
+    attenuation: 12db
+    internal: true
+
+  # CT Clamp sensors -- calibrate after install
+  - platform: ct_clamp
+    sensor: adc_ch1
+    name: "CT1 Current"
+    id: ct1Amps
+    update_interval: never
+    sample_duration: 200ms
+    unit_of_measurement: A
+    device_class: current
+    accuracy_decimals: 2
+    filters:
+      - calibrate_linear:
+          method: exact
+          datapoints:
+            - 0 -> 0
+            - 0.01 -> 1     # Adjust after calibration
+      - lambda: "return max(x, 0.0f);"
+
+  - platform: ct_clamp
+    sensor: adc_ch2
+    name: "CT2 Current"
+    id: ct2Amps
+    update_interval: never
+    sample_duration: 200ms
+    unit_of_measurement: A
+    device_class: current
+    accuracy_decimals: 2
+    filters:
+      - calibrate_linear:
+          method: exact
+          datapoints:
+            - 0 -> 0
+            - 0.01 -> 1
+      - lambda: "return max(x, 0.0f);"
+
+  - platform: ct_clamp
+    sensor: adc_ch3
+    name: "CT3 Current"
+    id: ct3Amps
+    update_interval: never
+    sample_duration: 200ms
+    unit_of_measurement: A
+    device_class: current
+    accuracy_decimals: 2
+    filters:
+      - calibrate_linear:
+          method: exact
+          datapoints:
+            - 0 -> 0
+            - 0.01 -> 1
+      - lambda: "return max(x, 0.0f);"
+
+  - platform: ct_clamp
+    sensor: adc_ch4
+    name: "CT4 Current"
+    id: ct4Amps
+    update_interval: never
+    sample_duration: 200ms
+    unit_of_measurement: A
+    device_class: current
+    accuracy_decimals: 2
+    filters:
+      - calibrate_linear:
+          method: exact
+          datapoints:
+            - 0 -> 0
+            - 0.01 -> 1
+      - lambda: "return max(x, 0.0f);"
+
+  - platform: wifi_signal
+    name: "WiFi Signal"
+    update_interval: 60s
+
+  - platform: uptime
+    name: "Uptime"
+
+switch:
+  - platform: restart
+    name: "Restart"

--- a/src/docs/devices/Mottramlabs-MLP201193/config.yaml
+++ b/src/docs/devices/Mottramlabs-MLP201193/config.yaml
@@ -11,8 +11,6 @@ wifi:
   power_save_mode: none
   ap:
 
-captive_portal:
-
 logger:
 
 sensor:

--- a/src/docs/devices/Mottramlabs-MLP201193/index.md
+++ b/src/docs/devices/Mottramlabs-MLP201193/index.md
@@ -1,0 +1,66 @@
+---
+title: MottramLabs MLP201193 ESP32 4-Channel Mains Power Sensor
+date-published: 2026-07-18
+type: sensor
+standard: uk
+board: esp32
+project-url: https://github.com/Mottramlabs/4-Channel-Mains-Current-Sensor
+difficulty: 4
+made-for-esphome: false
+---
+
+![MLP201193](mottramlabs-mlp201193.jpg "MottramLabs MLP201193 ESP32 4-Channel Mains Power Sensor")
+
+A 4-channel mains power sensor board using an ESP32 (NodeMCU 38-Pin ESP32) from [MottramLabs](https://www.mottramlabs.com/ct_products.html).
+
+**Product page:** https://www.mottramlabs.com/ct_products.html (last item on the page)
+**Schematic (V2):** https://www.mottramlabs.com/pdf/SCH201193.pdf
+**eBay listing:** https://www.ebay.co.uk/itm/134575710584
+
+## Hardware
+
+- **MCU:** ESP32-WROOM-32 (rev 3.1, dual-core, 4MB flash)
+- **USB bridge:** CP2102
+- **ADC channels:** All on ADC1 (WiFi-compatible, input-only GPIOs)
+
+### GPIO Mapping (from SCH201193 V2)
+
+| Channel | Jack | GPIO | ADC Channel |
+|---------|------|------|-------------|
+| CH1     | J1   | GPIO34 (D34) | ADC1_CH6 |
+| CH2     | J2   | GPIO35 (D35) | ADC1_CH7 |
+| CH3     | J3   | GPIO36 (D36) | ADC1_CH0 |
+| CH4     | J4   | GPIO39 (D39) | ADC1_CH3 |
+
+**Note:** GPIO34/35/36/39 are input-only pins with no internal pull-up/pull-down. This is fine for ADC use.
+
+### CT Clamp Selection
+
+The board has solder jumpers to select between:
+
+- **mA (current-type) CT clamps** — e.g. SCT-013-000 (100A/50mA) with onboard burden resistor
+- **1V (voltage-type) CT clamps** — e.g. SCT-013-030 (100A/1V) with burden resistor bypassed
+
+Ensure the jumpers match your CT clamp type before use.
+
+## Calibration
+
+The `calibrate_linear` filter maps raw ADC voltage to actual current (Amps). You need at least two datapoints: one for zero (idle) and one for a known load.
+
+1. Connect a known load (e.g. a kettle, heater) and measure actual current with a multimeter.
+2. Update the `calibrate_linear` datapoints in the config.
+3. Adjust the voltage multiplier (`240`) in the `on_value` lambda if your mains voltage differs (e.g. `120` for US).
+
+The `max(x, 0.0f)` lambda prevents negative readings from noise.
+
+## Configuration
+
+```yaml file=config.yaml
+```
+
+### Power and Energy Sensors (optional)
+
+This additional configuration adds power (Watts) and daily energy (kWh) sensors derived from the CT clamp current readings. The power calculation uses `Amps x 240V` for UK mains. Adjust the voltage multiplier for your region.
+
+```yaml file=power.yaml
+```

--- a/src/docs/devices/Mottramlabs-MLP201193/index.md
+++ b/src/docs/devices/Mottramlabs-MLP201193/index.md
@@ -11,11 +11,14 @@ made-for-esphome: false
 
 ![MLP201193](mottramlabs-mlp201193.jpg "MottramLabs MLP201193 ESP32 4-Channel Mains Power Sensor")
 
-A 4-channel mains power sensor board using an ESP32 (NodeMCU 38-Pin ESP32) from [MottramLabs](https://www.mottramlabs.com/ct_products.html).
+A 4-channel mains power sensor board using an ESP32
+(NodeMCU 38-Pin ESP32) from
+[MottramLabs](https://www.mottramlabs.com/ct_products.html).
 
-**Product page:** https://www.mottramlabs.com/ct_products.html (last item on the page)
-**Schematic (V2):** https://www.mottramlabs.com/pdf/SCH201193.pdf
-**eBay listing:** https://www.ebay.co.uk/itm/134575710584
+- [Product page](https://www.mottramlabs.com/ct_products.html)
+  (last item on the page)
+- [Schematic (V2)](https://www.mottramlabs.com/pdf/SCH201193.pdf)
+- [eBay listing](https://www.ebay.co.uk/itm/134575710584)
 
 ## Hardware
 
@@ -32,24 +35,31 @@ A 4-channel mains power sensor board using an ESP32 (NodeMCU 38-Pin ESP32) from 
 | CH3     | J3   | GPIO36 (D36) | ADC1_CH0 |
 | CH4     | J4   | GPIO39 (D39) | ADC1_CH3 |
 
-**Note:** GPIO34/35/36/39 are input-only pins with no internal pull-up/pull-down. This is fine for ADC use.
+**Note:** GPIO34/35/36/39 are input-only pins with no internal
+pull-up/pull-down. This is fine for ADC use.
 
 ### CT Clamp Selection
 
 The board has solder jumpers to select between:
 
-- **mA (current-type) CT clamps** — e.g. SCT-013-000 (100A/50mA) with onboard burden resistor
-- **1V (voltage-type) CT clamps** — e.g. SCT-013-030 (100A/1V) with burden resistor bypassed
+- **mA (current-type) CT clamps** — e.g. SCT-013-000 (100A/50mA)
+  with onboard burden resistor
+- **1V (voltage-type) CT clamps** — e.g. SCT-013-030 (100A/1V)
+  with burden resistor bypassed
 
 Ensure the jumpers match your CT clamp type before use.
 
 ## Calibration
 
-The `calibrate_linear` filter maps raw ADC voltage to actual current (Amps). You need at least two datapoints: one for zero (idle) and one for a known load.
+The `calibrate_linear` filter maps raw ADC voltage to actual
+current (Amps). You need at least two datapoints: one for zero
+(idle) and one for a known load.
 
-1. Connect a known load (e.g. a kettle, heater) and measure actual current with a multimeter.
+1. Connect a known load (e.g. a kettle, heater) and measure
+   actual current with a multimeter.
 2. Update the `calibrate_linear` datapoints in the config.
-3. Adjust the voltage multiplier (`240`) in the `on_value` lambda if your mains voltage differs (e.g. `120` for US).
+3. Adjust the voltage multiplier (`240`) in the `on_value` lambda
+   if your mains voltage differs (e.g. `120` for US).
 
 The `max(x, 0.0f)` lambda prevents negative readings from noise.
 
@@ -60,7 +70,10 @@ The `max(x, 0.0f)` lambda prevents negative readings from noise.
 
 ### Power and Energy Sensors (optional)
 
-This additional configuration adds power (Watts) and daily energy (kWh) sensors derived from the CT clamp current readings. The power calculation uses `Amps x 240V` for UK mains. Adjust the voltage multiplier for your region.
+This additional configuration adds power (Watts) and daily energy
+(kWh) sensors derived from the CT clamp current readings. The
+power calculation uses `Amps x 240V` for UK mains. Adjust the
+voltage multiplier for your region.
 
 ```yaml file=power.yaml
 ```

--- a/src/docs/devices/Mottramlabs-MLP201193/power.yaml
+++ b/src/docs/devices/Mottramlabs-MLP201193/power.yaml
@@ -1,3 +1,5 @@
+captive_portal:
+
 interval:
   - interval: 5s
     then:

--- a/src/docs/devices/Mottramlabs-MLP201193/power.yaml
+++ b/src/docs/devices/Mottramlabs-MLP201193/power.yaml
@@ -1,0 +1,99 @@
+interval:
+  - interval: 5s
+    then:
+      - script.execute: readCTs
+
+script:
+  - id: readCTs
+    then:
+      - component.update: ct1Amps
+      - delay: 300ms
+      - component.update: ct2Amps
+      - delay: 300ms
+      - component.update: ct3Amps
+      - delay: 300ms
+      - component.update: ct4Amps
+      - delay: 300ms
+
+sensor:
+  # Power (Watts) -- Amps x 240V (UK mains)
+  - platform: template
+    name: "CT1 Power"
+    id: ct1Watts
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: never
+    lambda: "return id(ct1Amps).state * 240;"
+
+  - platform: template
+    name: "CT2 Power"
+    id: ct2Watts
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: never
+    lambda: "return id(ct2Amps).state * 240;"
+
+  - platform: template
+    name: "CT3 Power"
+    id: ct3Watts
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: never
+    lambda: "return id(ct3Amps).state * 240;"
+
+  - platform: template
+    name: "CT4 Power"
+    id: ct4Watts
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: never
+    lambda: "return id(ct4Amps).state * 240;"
+
+  # Daily Energy (kWh) for HA Energy Dashboard
+  - platform: total_daily_energy
+    name: "CT1 Energy"
+    id: ct1Energy
+    power_id: ct1Watts
+    filters:
+      - multiply: 0.001
+    unit_of_measurement: kWh
+    device_class: energy
+    state_class: total_increasing
+
+  - platform: total_daily_energy
+    name: "CT2 Energy"
+    id: ct2Energy
+    power_id: ct2Watts
+    filters:
+      - multiply: 0.001
+    unit_of_measurement: kWh
+    device_class: energy
+    state_class: total_increasing
+
+  - platform: total_daily_energy
+    name: "CT3 Energy"
+    id: ct3Energy
+    power_id: ct3Watts
+    filters:
+      - multiply: 0.001
+    unit_of_measurement: kWh
+    device_class: energy
+    state_class: total_increasing
+
+  - platform: total_daily_energy
+    name: "CT4 Energy"
+    id: ct4Energy
+    power_id: ct4Watts
+    filters:
+      - multiply: 0.001
+    unit_of_measurement: kWh
+    device_class: energy
+    state_class: total_increasing


### PR DESCRIPTION
Adds the MottramLabs MLP201193 ESP32 4-Channel Mains Power Sensor to the device registry.

**Board:** MLP201193 - ESP32 4-Channel Mains Power Sensor (NodeMCU 38-Pin)
**Product page:** https://www.mottramlabs.com/ct_products.html
**Schematic (V2):** https://www.mottramlabs.com/pdf/SCH201193.pdf
**eBay listing:** https://www.ebay.co.uk/itm/134575710584

### What's included

- `config.yaml` — Core hardware config: 4x CT clamp sensors on GPIO34/35/36/39, WiFi signal, uptime, restart switch
- `power.yaml` — Optional: power (W) and daily energy (kWh) template sensors for the HA Energy Dashboard
- `index.md` — Device documentation with GPIO mapping, calibration notes, and CT clamp selection info

### Hardware details

- ESP32-WROOM-32 (rev 3.1, dual-core, 4MB flash)
- CP2102 USB bridge
- 4x ADC channels on ADC1 (WiFi-compatible)
- Solder jumpers for mA vs 1V CT clamp types

### Notes

- Uses `esp-idf` framework (required for proper ADC handling on ESP32)
- All GPIOs are input-only (GPIO34/35/36/39) — no conflicts with WiFi
- Tested and working with Home Assistant integration via ESPHome API