### PR TITLE
Guition ESP32-S3-4848S040 config update

### DIFF
--- a/src/docs/devices/Guition-ESP32-S3-4848S040/config.yaml
+++ b/src/docs/devices/Guition-ESP32-S3-4848S040/config.yaml
@@ -1,0 +1,60 @@
+esphome:
+  name: guition-esp32-s3-4848s040
+  friendly_name: Guition ESP32-S3-4848S040
+
+esp32:
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+logger:
+  hardware_uart: UART0
+  baud_rate: 921600
+
+spi:
+  - type: single
+    id: id_spi
+    clk_pin: GPIO48
+    mosi_pin: GPIO47
+    miso_pin: GPIO41
+    interface: hardware
+
+i2c:
+  - id: id_touchscreen_bus
+    scl:
+      ignore_strapping_warning: true
+      number: GPIO45
+    sda: GPIO19
+
+psram:
+  mode: octal
+  speed: 80MHZ
+
+display:
+  - platform: mipi_rgb
+    model: GUITION-4848S040
+    id: id_tft_display
+    show_test_card: true
+    # uncomment for placement with down-facing USB socket:
+    # rotation: 90° 
+
+touchscreen:
+  - platform: gt911
+    display: id_tft_display
+    id: id_tft_touch
+
+light:
+  - platform: monochromatic
+    default_transition_length: 1s
+    id: id_display_backlight
+    name: Backlight
+    output: id_backlight_output
+    restore_mode: RESTORE_DEFAULT_ON
+
+output:
+  - platform: ledc
+    frequency: 150Hz
+    id: id_backlight_output
+    min_power: 0.01
+    pin: GPIO38
+    zero_means_zero: true

--- a/src/docs/devices/Guition-ESP32-S3-4848S040/config.yaml
+++ b/src/docs/devices/Guition-ESP32-S3-4848S040/config.yaml
@@ -36,7 +36,7 @@ display:
     id: id_tft_display
     show_test_card: true
     # uncomment for placement with down-facing USB socket:
-    # rotation: 90° 
+    # rotation: 90°
 
 touchscreen:
   - platform: gt911

--- a/src/docs/devices/Guition-ESP32-S3-4848S040/index.md
+++ b/src/docs/devices/Guition-ESP32-S3-4848S040/index.md
@@ -21,133 +21,35 @@ difficulty: 2
 
 ## Product description
 
-Avalible on [AliExpress](https://www.aliexpress.com/item/3256806115962222.html) at various vendors. Can be purchased
+Avalible on [AliExpress](https://www.aliexpress.com/item/1005008214679682.html) at various vendors. Can be purchased
 with or without the relay module, which does not fit into a standard EU round 60mm box.
+
+More info: http://pan.jczn1688.com/directlink/1/ESP32%20module/4.0inch_ESP32-4848S040.zip (schematics in `5-IO pin distribution`)
 
 ![Connector pinout](./guition-esp32-s3-4848s040-connector.jpg "Connector pinout")
 
 ## Basic Config
 
-```yaml
-esphome:
-  name: "guition-esp32-s3-4848s040"
-  friendly_name: "4848s040"
+```yaml file=config.yaml
+```
 
-esp32:
-  variant: esp32s3
-  framework:
-    type: esp-idf
+## Disable display backlight during OTA update
 
-psram:
-  mode: octal
-  speed: 80MHz
+The display flickers during the OTA update. To prevent this, you can turn off the backlight during the OTA update.
 
-logger:
-
-api:
-  encryption:
-    key: !secret encryption_key
-
+```yaml inline
 ota:
   - platform: esphome
-    password: !secret ota_password
-    on_begin: # prevent screen flickering during OTA
-      - light.turn_off:
-          id: display_backlight
-          transition_length: 0s
-      - lambda: "id(display_backlight).loop();"
-
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-
-switch:
-  - platform: gpio
-    name: Relay 1
-    pin:
-      number: GPIO40
-      inverted: true
-  - platform: gpio
-    name: Relay 2
-    pin:
-      number: GPIO2
-      inverted: true
-  - platform: gpio
-    name: Relay 3
-    pin:
-      number: GPIO1
-      inverted: true
-
-output:
-  - platform: ledc
-    id: backlight_output
-    pin: GPIO38
-    frequency: 150Hz
-    min_power: 0.01
-    zero_means_zero: true
+    # ...
+    on_begin:
+      then:
+        - light.turn_off:
+            id: id_display_backlight
+            transition_length: 0s
+        - lambda: id(id_display_backlight).loop();
 
 light:
   - platform: monochromatic
-    name: Backlight
-    id: display_backlight
-    output: backlight_output
+    # ...
     restore_mode: ALWAYS_ON
-    default_transition_length: 1s
-
-spi:
-  - id: lcd_spi
-    clk_pin: GPIO48
-    mosi_pin: GPIO47
-
-i2c:
-  id: touchscreen_bus
-  sda: GPIO19
-  scl:
-    number: 45
-    ignore_strapping_warning: true
-
-display:
-  - platform: st7701s
-    id: tft_display
-    dimensions:
-      width: 480
-      height: 480
-    #    rotation: 270    #uncomment for placement with down-facing USB socket
-    spi_mode: MODE3
-    data_rate: 2MHz
-    color_order: RGB
-    invert_colors: False
-    cs_pin: 39
-    de_pin: 18
-    hsync_pin: 16
-    vsync_pin: 17
-    pclk_pin: 21
-    pclk_frequency: 12MHz
-    pclk_inverted: False
-    hsync_pulse_width: 8
-    hsync_front_porch: 10
-    hsync_back_porch: 20
-    vsync_pulse_width: 8
-    vsync_front_porch: 10
-    vsync_back_porch: 10
-    update_interval: never
-    auto_clear_enabled: False
-    init_sequence:
-      - 1
-      - [0xFF, 0x77, 0x01, 0x00, 0x00, 0x10] # CMD2_BKSEL_BK0
-      - [0xCD, 0x00] # disable MDT flag
-    data_pins:
-      red: [11, 12, 13, 14, 0]
-      green: [8, 20, 3, 46, 9, 10]
-      blue: [4, 5, 6, 7, 15]
-
-touchscreen:
-  - platform: gt911
-    id: tft_touch
-    display: tft_display
-#    transform:     #uncomment for placement with down-facing USB socket
-#      swap_xy: true
-#      mirror_x: true
-
-lvgl:
 ```

--- a/src/docs/devices/Guition-ESP32-S3-4848S040/index.md
+++ b/src/docs/devices/Guition-ESP32-S3-4848S040/index.md
@@ -24,7 +24,8 @@ difficulty: 2
 Avalible on [AliExpress](https://www.aliexpress.com/item/1005008214679682.html) at various vendors. Can be purchased
 with or without the relay module, which does not fit into a standard EU round 60mm box.
 
-[Documentation .zip](http://pan.jczn1688.com/directlink/1/ESP32%20module/4.0inch_ESP32-4848S040.zip) (schematics in `5-IO pin distribution`)
+[Documentation .zip](http://pan.jczn1688.com/directlink/1/ESP32%20module/4.0inch_ESP32-4848S040.zip)
+(schematics in `5-IO pin distribution`)
 
 ![Connector pinout](./guition-esp32-s3-4848s040-connector.jpg "Connector pinout")
 

--- a/src/docs/devices/Guition-ESP32-S3-4848S040/index.md
+++ b/src/docs/devices/Guition-ESP32-S3-4848S040/index.md
@@ -24,7 +24,7 @@ difficulty: 2
 Avalible on [AliExpress](https://www.aliexpress.com/item/1005008214679682.html) at various vendors. Can be purchased
 with or without the relay module, which does not fit into a standard EU round 60mm box.
 
-More info: http://pan.jczn1688.com/directlink/1/ESP32%20module/4.0inch_ESP32-4848S040.zip (schematics in `5-IO pin distribution`)
+[Documentation .zip](http://pan.jczn1688.com/directlink/1/ESP32%20module/4.0inch_ESP32-4848S040.zip) (schematics in `5-IO pin distribution`)
 
 ![Connector pinout](./guition-esp32-s3-4848s040-connector.jpg "Connector pinout")
 


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

- added link to schematics .zip file
- replaced dead aliexpress link
- updated display to mipi_rgb platform
- added logger configuration


## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [X] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [X] The first `file=` fence on the page references `config.yaml`.
- [X] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [X] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
