### PR TITLE
Improve light sensor discoverability

### DIFF
--- a/src/docs/devices/Tuya-ZY-HPS01-Human-Presence-Sensor/config.yaml
+++ b/src/docs/devices/Tuya-ZY-HPS01-Human-Presence-Sensor/config.yaml
@@ -1,0 +1,92 @@
+esphome:
+  name: ZY-HPS01 Human presence sensor
+  friendly_name: Human presence sensor
+
+bk72xx:
+  board: cb3s
+
+uart:
+  - baud_rate: 9600
+    tx_pin: 11
+    rx_pin: 10
+tuya:
+
+sensor:
+  - platform: tuya
+    name: "Light Intensity"
+    id: light_intensity
+    sensor_datapoint: 103
+    unit_of_measurement: "lx"
+    device_class: "illuminance"
+    icon: "mdi:brightness-5"
+    state_class: "measurement"
+
+number:
+  - platform: "tuya"
+    name: "Far Detection"
+    number_datapoint: 109
+    min_value: 0
+    max_value: 600
+    step: 1
+    mode: slider
+    unit_of_measurement: "cm"
+    icon: "mdi:signal-distance-variant"
+  - platform: "tuya"
+    name: "Presence Delay"
+    number_datapoint: 104
+    min_value: 1
+    max_value: 255
+    step: 1
+    mode: slider
+    unit_of_measurement: "s"
+    icon: "mdi:timer"
+  - platform: "tuya"
+    name: "Sensitivity"
+    number_datapoint: 105
+    min_value: 0
+    max_value: 10
+    step: 1
+    mode: slider
+    icon: "mdi:ray-vertex"
+  - platform: "tuya"
+    name: "Micro Sensitivity"
+    number_datapoint: 107
+    min_value: 0
+    max_value: 10
+    step: 1
+    mode: slider
+    icon: "mdi:ray-vertex"
+  - platform: "tuya"
+    name: "Min Range"
+    number_datapoint: 110
+    min_value: 0
+    max_value: 600
+    step: 1
+    mode: slider
+    unit_of_measurement: "cm"
+    icon: "mdi:signal-distance-variant"
+  - platform: "tuya"
+    name: "Micro Max Range"
+    number_datapoint: 111
+    min_value: 0
+    max_value: 600
+    step: 1
+    mode: slider
+    unit_of_measurement: "cm"
+    icon: "mdi:signal-distance-variant"
+  - platform: "tuya"
+    name: "Micro Min Range"
+    number_datapoint: 112
+    min_value: 0
+    max_value: 600
+    step: 1
+    mode: slider
+    unit_of_measurement: "cm"
+    icon: "mdi:signal-distance-variant"
+binary_sensor:
+  - platform: "tuya"
+    name: "Presence State"
+    sensor_datapoint: 101
+    device_class: occupancy
+    filters:
+      - invert:

--- a/src/docs/devices/Tuya-ZY-HPS01-Human-Presence-Sensor/index.md
+++ b/src/docs/devices/Tuya-ZY-HPS01-Human-Presence-Sensor/index.md
@@ -47,107 +47,14 @@ Some users have reported that they had trouble getting into programming mode. Tr
 
 ## ZY-HPS01 Configuration
 
-```yaml
-esphome:
-  name: ZY-HPS01 Human presence sensor
-  friendly_name: Human presence sensor
-
-bk72xx:
-  board: cb3s
-
-uart:
-  - baud_rate: 9600
-    tx_pin: 11
-    rx_pin: 10
-tuya:
-
-sensor:
-  - platform: tuya
-    name: "Light Intensity"
-    id: light_intensity
-    sensor_datapoint: 103
-    unit_of_measurement: "lx"
-    device_class: "illuminance"
-    icon: "mdi:brightness-5"
-    state_class: "measurement"
-
-number:
-  - platform: "tuya"
-    name: "Far Detection"
-    number_datapoint: 109
-    min_value: 0
-    max_value: 600
-    step: 1
-    mode: slider
-    unit_of_measurement: "cm"
-    icon: "mdi:signal-distance-variant"
-  - platform: "tuya"
-    name: "Presence Delay"
-    number_datapoint: 104
-    min_value: 1
-    max_value: 255
-    step: 1
-    mode: slider
-    unit_of_measurement: "s"
-    icon: "mdi:timer"
-  - platform: "tuya"
-    name: "Sensitivity"
-    number_datapoint: 105
-    min_value: 0
-    max_value: 10
-    step: 1
-    mode: slider
-    icon: "mdi:ray-vertex"
-  - platform: "tuya"
-    name: "Micro Sensitivity"
-    number_datapoint: 107
-    min_value: 0
-    max_value: 10
-    step: 1
-    mode: slider
-    icon: "mdi:ray-vertex"
-  - platform: "tuya"
-    name: "Min Range"
-    number_datapoint: 110
-    min_value: 0
-    max_value: 600
-    step: 1
-    mode: slider
-    unit_of_measurement: "cm"
-    icon: "mdi:signal-distance-variant"
-  - platform: "tuya"
-    name: "Micro Max Range"
-    number_datapoint: 111
-    min_value: 0
-    max_value: 600
-    step: 1
-    mode: slider
-    unit_of_measurement: "cm"
-    icon: "mdi:signal-distance-variant"
-  - platform: "tuya"
-    name: "Micro Min Range"
-    number_datapoint: 112
-    min_value: 0
-    max_value: 600
-    step: 1
-    mode: slider
-    unit_of_measurement: "cm"
-    icon: "mdi:signal-distance-variant"
-binary_sensor:
-  - platform: "tuya"
-    name: "Presence State"
-    sensor_datapoint: 101
-    device_class: occupancy
-    filters:
-      - invert:
-
+```yaml file=config.yaml
 ```
 
 ## ZY-ZHPS01 Configuration
 
 This variant will work by simply changing the illuminance sensor datapoint ID in the other configuration from 103 to 11.
 
-```yaml
+```yaml inline
 sensor:
   - platform: tuya
     name: "Light Intensity"

--- a/src/docs/devices/Tuya-ZY-HPS01-Human-Presence-Sensor/index.md
+++ b/src/docs/devices/Tuya-ZY-HPS01-Human-Presence-Sensor/index.md
@@ -66,7 +66,8 @@ sensor:
     name: "Light Intensity"
     id: light_intensity
     sensor_datapoint: 103
-    unit_of_measurement: "lux"
+    unit_of_measurement: "lx"
+    device_class: "illuminance"
     icon: "mdi:brightness-5"
     state_class: "measurement"
 


### PR DESCRIPTION
- Change unit of measurement from 'lux' to 'lx'
- Add device class

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [ ] The first `file=` fence on the page references `config.yaml`.
- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
