### PR TITLE
Remove BK7238 support notes and related configuration from LSC Smart Plug 3202087.2

### DIFF
--- a/src/docs/devices/LSC-Plug-3202087.2/bk7238-note.yaml
+++ b/src/docs/devices/LSC-Plug-3202087.2/bk7238-note.yaml
@@ -1,8 +1,0 @@
-esphome:
-  platformio_options:
-    custom_versions.beken-bdk: 3.0.78
-
-bk72xx:
-  framework:
-    version: 0.0.0
-    source: https://github.com/libretiny-eu/libretiny#feature/bk7238

--- a/src/docs/devices/LSC-Plug-3202087.2/config.yaml
+++ b/src/docs/devices/LSC-Plug-3202087.2/config.yaml
@@ -7,15 +7,10 @@ substitutions:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
-  platformio_options:
-    custom_versions.beken-bdk: 3.0.78
 
 bk72xx:
   board: generic-bk7238-tuya
   family: BK7238
-  framework:
-    version: 0.0.0
-    source: https://github.com/libretiny-eu/libretiny#feature/bk7238
 
 logger:
   baud_rate: 0

--- a/src/docs/devices/LSC-Plug-3202087.2/index.md
+++ b/src/docs/devices/LSC-Plug-3202087.2/index.md
@@ -80,16 +80,6 @@ after you add networking.
 ```yaml file=advanced.yaml
 ```
 
-## BK7238 Support Status
-
-At the time of writing, BK7238 support is still being worked on in ESPHome/LibreTiny. The example configuration
-therefore pins the Beken SDK version and pulls LibreTiny from the BK7238 feature branch:
-
-```yaml file=bk7238-note.yaml
-```
-
-Once BK7238 support lands in regular releases, these overrides may no longer be required.
-
 ## BL0937 Calibration
 
 Start with the values shown in `config.yaml` and calibrate them with a trusted external meter plus a resistive load


### PR DESCRIPTION
…Connect Power Plug documentation

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [x] Adding a new device adds a single device only — one device per pull request.
- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [x] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
