### PR TITLE
Update LSC Smart Connect Switch - fix broken links

### DIFF
--- a/src/docs/devices/LSC-Smart-Connect-Switch/config.yaml
+++ b/src/docs/devices/LSC-Smart-Connect-Switch/config.yaml
@@ -1,0 +1,48 @@
+substitutions:
+  plug_name: lsc-powerplug1
+
+esphome:
+  name: ${plug_name}
+
+esp8266:
+  board: esp01_1m
+
+binary_sensor:
+  # Binary sensor for the button press
+  - platform: status
+    name: ${plug_name}_status
+  - platform: gpio
+    pin:
+      number: GPIO13
+      mode: INPUT_PULLUP
+      inverted: true
+    name: ${plug_name}_button
+    internal: true
+    on_press:
+      - switch.toggle: relay
+
+output:
+  # Relay state led
+  - platform: esp8266_pwm
+    id: state_led
+    pin:
+      number: GPIO4
+      inverted: true
+
+light:
+  # Relay state light
+  - platform: monochromatic
+    id: led
+    name: ${plug_name}_led
+    output: state_led
+
+switch:
+  # Switch toggles relay
+  - platform: gpio
+    id: relay
+    name: ${plug_name}_relay
+    pin: GPIO12
+    on_turn_on:
+      - light.turn_on: led
+    on_turn_off:
+      - light.turn_off: led

--- a/src/docs/devices/LSC-Smart-Connect-Switch/index.md
+++ b/src/docs/devices/LSC-Smart-Connect-Switch/index.md
@@ -14,11 +14,6 @@ The latest LSC Smart Connect Switch devices use the Tuya WB2S module, which is n
 
 - This plug is flashable using the latest tuya-convert with a compiled ESPHome binary
 
-## Product Images
-
-![plug with box](https://www.action.com/globalassets/cmsarticleimages/79/77/2578677_8712879142799-111.png?preset=mediaSliderImageLargeHD)
-![plug](https://www.action.com/globalassets/cmsarticleimages/79/78/2578677_8712879142799-110_02.png?preset=mediaSliderImageLargeHD)
-
 ## GPIO Pinout
 
 | Pin    | Function                            |
@@ -29,65 +24,8 @@ The latest LSC Smart Connect Switch devices use the Tuya WB2S module, which is n
 
 ## Basic configuration
 
-```yml
-substitutions:
-  plug_name: lsc-powerplug1
-
-esphome:
-  name: ${plug_name}
-
-esp8266:
-  board: esp01_1m
-
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-
-api:
-logger:
-ota:
-
-binary_sensor:
-  # Binary sensor for the button press
-  - platform: status
-    name: ${plug_name}_status
-  - platform: gpio
-    pin:
-      number: GPIO13
-      mode: INPUT_PULLUP
-      inverted: true
-    name: ${plug_name}_button
-    internal: true
-    on_press:
-      - switch.toggle: relay
-
-output:
-  # Relay state led
-  - platform: esp8266_pwm
-    id: state_led
-    pin:
-      number: GPIO4
-      inverted: true
-
-light:
-  # Relay state light
-  - platform: monochromatic
-    id: led
-    name: ${plug_name}_led
-    output: state_led
-
-switch:
-  # Switch toggles relay
-  - platform: gpio
-    id: relay
-    name: ${plug_name}_relay
-    pin: GPIO12
-    on_turn_on:
-      - light.turn_on: led
-    on_turn_off:
-      - light.turn_off: led
-```
+```yaml file=config.yaml
 
 [https://thibmaek.com/posts/flashing-esphome-to-lsc-smart-connect-action-switches-power-plugs](https://thibmaek.com/posts/flashing-esphome-to-lsc-smart-connect-action-switches-power-plugs)
 
-[Tasmota template LSC power plug](https://templates.blakadder.com/lsc_smart_connect_power_plug.html)
+[Tasmota template LSC power plug](https://templates.blakadder.com/unsupported/lsc_smart_connect_power_plug.html)


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Updates the LSC Smart Connect Switch page to:

- point the Tasmota template link at its current `/unsupported/` location;
- remove two product image links whose host no longer resolves; and
- move the legacy inline ESPHome example into a hardware-only `config.yaml`, as required for modified device pages.

This addresses one device entry from #1576 without closing the broader tracking issue.

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

The new-device and `made-for-esphome` checklist items are not applicable to this existing, unflagged device page.

## Checks

- `npm run --silent validate-devices`
- `npm run --silent lint-frontmatter -- upstream/main HEAD`
- `npm run check-links -- upstream/main HEAD`
- `yamllint -c .yamllintrc src/docs/devices/LSC-Smart-Connect-Switch/config.yaml`
- `git diff --check upstream/main...HEAD`

## Assistance disclosure

This contribution was prepared with OpenAI Codex assistance. The final diff and repository-provided checks were reviewed before submission.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
