### PR TITLE
TH3D-EZPlug-Plus Refactor

### DIFF
--- a/src/docs/devices/TH3D-EZPlug-Plus/config.yaml
+++ b/src/docs/devices/TH3D-EZPlug-Plus/config.yaml
@@ -13,8 +13,6 @@ wifi:
 
 logger:
 
-captive_portal:
-
 time:
   - platform: sntp
     id: sntp_time

--- a/src/docs/devices/TH3D-EZPlug-Plus/config.yaml
+++ b/src/docs/devices/TH3D-EZPlug-Plus/config.yaml
@@ -1,0 +1,113 @@
+esphome:
+  name: th3d-ezplug-plus
+  friendly_name: "TH3D EZPlug Plus"
+
+esp8266:
+  board: esp01_1m
+  restore_from_flash: true
+  early_pin_init: true
+
+wifi:
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap: {}
+
+logger:
+
+captive_portal:
+
+time:
+  - platform: sntp
+    id: sntp_time
+
+text_sensor:
+  - platform: version
+    name: Version
+  - platform: wifi_info
+    ip_address:
+      name: IP Address
+    ssid:
+      name: SSID
+    bssid:
+      name: BSSID
+    mac_address:
+      name: MAC Address
+    scan_results:
+      name: Scan Results
+
+switch:
+  - platform: restart
+    name: Restart
+  - platform: gpio
+    pin: GPIO14
+    id: relay
+    restore_mode: RESTORE_DEFAULT_OFF
+    name: Relay
+    on_turn_on:
+      - light.turn_on: led
+    on_turn_off:
+      - light.turn_off: led
+
+sensor:
+  - platform: uptime
+    name: Uptime
+    device_class: "duration"
+    unit_of_measurement: s
+    accuracy_decimals: 0
+  - platform: wifi_signal
+    name: Wifi Signal Strength
+    update_interval: 5min
+  - platform: hlw8012
+    sel_pin:
+      number: GPIO12
+      inverted: true
+    cf_pin: GPIO4
+    cf1_pin: GPIO5
+    model: BL0937
+    voltage_divider: 1776
+    current:
+      name: Current
+      unit_of_measurement: A
+      accuracy_decimals: 3
+      # Overcurrent protection. Device is rated for 15A
+      on_value_range:
+        - above: 15
+          then:
+            - switch.turn_off: relay
+    voltage:
+      name: Voltage
+      unit_of_measurement: V
+      accuracy_decimals: 1
+    power:
+      name: Power
+      id: power
+      unit_of_measurement: "W"
+      accuracy_decimals: 0
+      icon: mdi:flash-outline
+    change_mode_every: 1
+    update_interval: 2s
+  - platform: total_daily_energy
+    name: Daily Energy
+    power_id: power
+    filters:
+      # 1 W = .001 kW
+      - multiply: 0.001
+    unit_of_measurement: kWh
+
+binary_sensor:
+  - platform: status
+    name: Status
+  - platform: gpio
+    pin:
+      number: GPIO3
+      mode: INPUT_PULLUP
+      inverted: True
+    name: Button
+    on_press:
+      - switch.toggle: relay
+
+light:
+  - platform: status_led
+    id: led
+    pin:
+      number: GPIO13
+      inverted: True

--- a/src/docs/devices/TH3D-EZPlug-Plus/index.md
+++ b/src/docs/devices/TH3D-EZPlug-Plus/index.md
@@ -13,7 +13,7 @@ board: esp8266
 | Pin    | Function                            |
 | -----  | ------------                        |
 | GPIO3  | Button Input                        |
-| GPIO4  | BL0937 Ennergy Meter CF             |
+| GPIO4  | BL0937 Energy Meter CF             |
 | GPIO5  | HLW8012 Power Sensor CF1            |
 | GPIO12 | HLW8012 Power Sensor SEL (Inverted) |
 | GPIO13 | Status LED (Inverted)               |
@@ -26,122 +26,5 @@ board: esp8266
 
 ## Basic Configuration
 
-```yaml
-esphome:
-  name: TH3D_EZPlug_Plus
-  restore_from_flash: true
-  early_pin_init: true
-
-esp8266:
-  board: esp01_1m
-
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-
-logger:
-api:
-ota:
-
-time:
-  - platform: homeassistant
-
-switch:
-  - platform: restart
-    name: Restart
-text_sensor:
-  - platform: version
-    name: Version
-  - platform: wifi_info
-    ip_address:
-      name: IP Address
-    ssid:
-      name: SSID
-    bssid:
-      name: BSSID
-    mac_address:
-      name: MAC Address
-    scan_results:
-      name: Scan Results
-switch:
-  - platform: gpio
-    pin: GPIO14
-    id: relay
-    restore_mode: RESTORE_DEFAULT_OFF
-    name: Relay
-    on_turn_on:
-      - light.turn_on: led
-    on_turn_off:
-      - light.turn_off: led
-
-sensor:
-  - platform: uptime
-    name: Uptime
-    device_class: "duration"
-    unit_of_measurement: s
-    accuracy_decimals: 0
-  - platform: wifi_signal
-    name: Wifi Signal Strength
-    update_interval: 5min
-  - platform: hlw8012
-    sel_pin:
-      number: GPIO12
-      inverted: true
-    cf_pin: GPIO4
-    cf1_pin: GPIO5
-    model: BL0937
-    voltage_divider: 512
-    current:
-      name: Current
-      unit_of_measurement: A
-      accuracy_decimals: 3
-    # Overcurrent protection.  Device is rated for 15A
-    on_value_range:
-        - above: 15
-          then:
-            - switch.turn_off: relay
-            - homeassistant.service:
-                service: persistent_notification.create
-                data:
-                  title: Message from TH3D_EZPlug_Plus
-                data_template:
-                  message: Switch turned off because power exceeded 15A
-    voltage:
-      name: Voltage
-      unit_of_measurement: V
-      accuracy_decimals: 1
-    power:
-      name: Power
-      id: power
-      unit_of_measurement: "W"
-      accuracy_decimals: 0
-      icon: mdi:flash-outline
-    change_mode_every: 1
-    update_interval: 2s
-  - platform: total_daily_energy
-    name: Daily Energy
-    power_id: power
-    filters:
-      # 1 W = .001 kW
-      - multiply: 0.001
-    unit_of_measurement: kWh
-
-binary_sensor:
-  - platform: status
-    name: Status
-  - platform: gpio
-    pin:
-      number: GPIO3
-      mode: INPUT_PULLUP
-      inverted: True
-    name: Button
-    on_press:
-      - switch.toggle: relay
-
-light:
-  - platform: status_led
-    id: led
-    pin:
-      number: GPIO13
-      inverted: True
+```yaml file=config.yaml
 ```

--- a/src/docs/devices/TH3D-EZPlug-Plus/index.md
+++ b/src/docs/devices/TH3D-EZPlug-Plus/index.md
@@ -1,6 +1,6 @@
 ---
 title: TH3D EZPlug+
-date-published: 2023-02-20
+date-published: 2026-07-26
 type: plug
 standard: us
 board: esp8266


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes



## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [x] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [ ] The first `file=` fence on the page references `config.yaml`.
- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
