### PR TITLE
Auto-label PRs by "Type of changes" checkbox

### DIFF
--- a/.github/workflows/label-pr-type.yml
+++ b/.github/workflows/label-pr-type.yml
@@ -1,0 +1,92 @@
+name: Label PR by type
+
+# Reads the "Type of changes" section of the pull request description and
+# applies the matching type label (new-device / update-device / remove-device /
+# cleanup / other) based on which checkboxes are ticked. Runs again whenever the
+# description is edited, so ticking or unticking a box keeps the labels in sync.
+# The labels themselves already exist in the repo.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions: {}
+
+jobs:
+  label:
+    name: Sync type labels
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # add/remove labels on the PR
+    steps:
+      - name: Sync labels from checklist
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            // Maps a checkbox under "## Type of changes" to the label it drives.
+            // `match` is tested against the checkbox's label text. Every entry is
+            // a "managed" label: unticking a box removes it again.
+            const LABELS = [
+              { name: 'new-device', match: /new device/i },
+              { name: 'update-device', match: /update existing device/i },
+              { name: 'remove-device', match: /removing a device/i },
+              { name: 'cleanup', match: /general cleanup/i },
+              { name: 'other', match: /other/i },
+            ];
+
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            // Isolate the "Type of changes" section so checkboxes in other
+            // sections (e.g. the "Checklist:" block, which also mentions
+            // "new device") can never trigger a label.
+            const section = body.match(/##\s*Type of changes\s*\n([\s\S]*?)(?:\n##\s|$)/i);
+            const scoped = section ? section[1] : '';
+
+            // Collect the text of every ticked checkbox in that section.
+            const ticked = [];
+            const checkbox = /^\s*-\s*\[[xX]\]\s*(.+?)\s*$/gm;
+            let m;
+            while ((m = checkbox.exec(scoped)) !== null) {
+              ticked.push(m[1]);
+            }
+
+            const desired = new Set(
+              LABELS.filter((l) => ticked.some((t) => l.match.test(t))).map((l) => l.name)
+            );
+            core.info(`Desired type labels: ${[...desired].join(', ') || '(none)'}`);
+
+            const managed = new Set(LABELS.map((l) => l.name));
+            const current = new Set(pr.labels.map((l) => l.name));
+
+            const toAdd = [...desired].filter((name) => !current.has(name));
+            const toRemove = [...managed].filter(
+              (name) => current.has(name) && !desired.has(name)
+            );
+
+            if (toAdd.length) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: toAdd,
+              });
+              core.info(`Added: ${toAdd.join(', ')}`);
+            }
+
+            for (const name of toRemove) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                name,
+              });
+              core.info(`Removed: ${name}`);
+            }
+
+            if (!toAdd.length && !toRemove.length) {
+              core.info('Labels already in sync.');
+            }

--- a/.github/workflows/label-pr-type.yml
+++ b/.github/workflows/label-pr-type.yml
@@ -20,6 +20,7 @@ jobs:
     name: Sync type labels
     runs-on: ubuntu-latest
     permissions:
+      issues: write  # labels are an issues-level resource
       pull-requests: write  # add/remove labels on the PR
     steps:
       - name: Sync labels from checklist
@@ -27,14 +28,15 @@ jobs:
         with:
           script: |
             // Maps a checkbox under "## Type of changes" to the label it drives.
-            // `match` is tested against the checkbox's label text. Every entry is
-            // a "managed" label: unticking a box removes it again.
+            // `match` is anchored at the start of the checkbox's label text so an
+            // unrelated box (e.g. "Another …") can't match by substring. Every
+            // entry is a "managed" label: unticking a box removes it again.
             const LABELS = [
-              { name: 'new-device', match: /new device/i },
-              { name: 'update-device', match: /update existing device/i },
-              { name: 'remove-device', match: /removing a device/i },
-              { name: 'cleanup', match: /general cleanup/i },
-              { name: 'other', match: /other/i },
+              { name: 'new-device', match: /^new device\b/i },
+              { name: 'update-device', match: /^update existing device\b/i },
+              { name: 'remove-device', match: /^removing a device\b/i },
+              { name: 'cleanup', match: /^general cleanup\b/i },
+              { name: 'other', match: /^other\b/i },
             ];
 
             const pr = context.payload.pull_request;
@@ -43,7 +45,8 @@ jobs:
             // Isolate the "Type of changes" section so checkboxes in other
             // sections (e.g. the "Checklist:" block, which also mentions
             // "new device") can never trigger a label.
-            const section = body.match(/##\s*Type of changes\s*\n([\s\S]*?)(?:\n##\s|$)/i);
+            // \r?\n throughout so CRLF bodies (common from the web editor) match.
+            const section = body.match(/##\s*Type of changes\s*\r?\n([\s\S]*?)(?:\r?\n##\s|$)/i);
             const scoped = section ? section[1] : '';
 
             // Collect the text of every ticked checkbox in that section.


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Adds a `Label PR by type` workflow that reads the "Type of changes" section of the pull request description and applies the matching label based on which checkboxes are ticked: New device → `new-device`, Update existing device → `update-device`, Removing a device → `remove-device`, General cleanup → `cleanup`, Other → `other`. It triggers on `pull_request_target` for `opened`, `edited`, and `reopened`, so ticking or unticking a box keeps the labels in sync. Parsing is scoped to the "Type of changes" section only, so the "Adding a new device…" line in the Checklist section can never trigger a label. The five labels have been created in the repository, so the workflow only adds and removes them.

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [ ] The first `file=` fence on the page references `config.yaml`.
- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->