### PR TITLE
Post a passing Made for ESPHome review comment

### DIFF
--- a/.github/scripts/mfe-review-feedback.cjs
+++ b/.github/scripts/mfe-review-feedback.cjs
@@ -11,12 +11,14 @@
 const fs = require("fs");
 const path = require("path");
 
-// Hidden markers so we only ever touch our own reviews and never the
+// Hidden markers so we only ever touch our own reviews/comments and never the
 // device-config validation review or the made-for-esphome checklist review
 // (both also bot REQUEST_CHANGES reviews). SUPERSEDED tags the stub we leave
-// behind when a newer review replaces an older one.
+// behind when a newer review replaces an older one; MARKER_PASS tags the
+// non-blocking "all checks pass" acknowledgement comment.
 const MARKER = "<!-- made-for-esphome-review -->";
 const SUPERSEDED = "<!-- mfe-superseded -->";
+const MARKER_PASS = "<!-- made-for-esphome-pass -->";
 
 module.exports = async ({ github, context, core }) => {
   const artifactDir = process.env.MFE_ARTIFACT_DIR || "artifact";
@@ -84,52 +86,86 @@ module.exports = async ({ github, context, core }) => {
     });
   };
 
-  if (hasReport) {
-    const body = `${MARKER}\n${fs.readFileSync(reportPath, "utf8").trim()}`;
+  const dismissActive = async (message) => {
+    for (const r of active) {
+      await github.rest.pulls.dismissReview({ ...common, review_id: r.id, message });
+    }
+    if (active.length) core.info(`Dismissed ${active.length} review(s) on PR #${prNumber}.`);
+  };
+
+  // The "all checks pass" acknowledgement is a plain issue comment (keyed by
+  // MARKER_PASS) — non-blocking, and cleanly upserted/removed.
+  const issueCommon = { owner: context.repo.owner, repo: context.repo.repo };
+  const findPassComment = async () => {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+      ...issueCommon,
+      issue_number: prNumber,
+      per_page: 100,
+    });
+    return comments.find((c) => c.body && c.body.includes(MARKER_PASS)) || null;
+  };
+  const removePassComment = async () => {
+    const existing = await findPassComment();
+    if (existing) {
+      await github.rest.issues.deleteComment({ ...issueCommon, comment_id: existing.id });
+      core.info(`Removed pass comment ${existing.id}.`);
+    }
+  };
+
+  const reportBody = hasReport ? fs.readFileSync(reportPath, "utf8").trim() : null;
+
+  if (status === "changes") {
+    if (!reportBody) {
+      core.warning("status is `changes` but no report was uploaded; leaving reviews untouched.");
+      return;
+    }
+    const body = `${MARKER}\n${reportBody}`;
     // workflow_run fires on every push; if the newest active review already
     // carries this exact content, nothing changed — skip so we don't spam a
     // fresh review on a no-op push.
     const newest = active[active.length - 1];
     if (newest && newest.body === body) {
       core.info(`Review ${newest.id} already current; nothing to do.`);
-      return;
+    } else {
+      // Move the old content to a stub and post a new review lower down rather
+      // than editing in place.
+      for (const r of active) {
+        await supersede(r);
+      }
+      // Reviews are only ever REQUEST_CHANGES (blocking) — never APPROVE.
+      await github.rest.pulls.createReview({ ...common, event: "REQUEST_CHANGES", body });
+      core.info(`Posted a new Made for ESPHome review on PR #${prNumber}.`);
     }
-    // When the PR is altered (or a review is re-requested and this re-runs),
-    // move the old content to a stub and post a new review lower down rather
-    // than editing in place.
-    for (const r of active) {
-      await supersede(r);
+    // A failing run must not leave a stale "all pass" acknowledgement behind.
+    await removePassComment();
+  } else if (status === "pass") {
+    // Genuine pass: unblock (dismiss any active review) and post/refresh the
+    // non-blocking green acknowledgement comment.
+    await dismissActive("Made for ESPHome checks now pass — dismissing.");
+    const passBody = `${MARKER_PASS}\n${
+      reportBody ?? "## ✅ Made for ESPHome review\n\nAll automated checks pass."
+    }`;
+    const existing = await findPassComment();
+    if (existing && existing.body === passBody) {
+      core.info(`Pass comment ${existing.id} already current.`);
+    } else if (existing) {
+      await github.rest.issues.updateComment({ ...issueCommon, comment_id: existing.id, body: passBody });
+      core.info(`Updated pass comment ${existing.id}.`);
+    } else {
+      await github.rest.issues.createComment({ ...issueCommon, issue_number: prNumber, body: passBody });
+      core.info(`Posted pass comment on PR #${prNumber}.`);
     }
-    // Reviews are only ever REQUEST_CHANGES (blocking) — never APPROVE.
-    await github.rest.pulls.createReview({
-      ...common,
-      event: "REQUEST_CHANGES",
-      body,
-    });
-    core.info(`Posted a new Made for ESPHome review on PR #${prNumber}.`);
-  } else if (status !== "pass" && status !== "no-mfe") {
-    // No report and not a genuine pass — the run was inconclusive (status
-    // `inconclusive`) or crashed (status file missing). Leave any existing
-    // blocking review in place; dismissing here would silently unblock a PR
-    // whose checks never actually completed.
+  } else if (status === "no-mfe") {
+    // No longer made-for-esphome: unblock and remove any acknowledgement.
+    await dismissActive("No longer made-for-esphome — dismissing.");
+    await removePassComment();
+  } else {
+    // `inconclusive` or a missing status file (a crashed run). Leave everything
+    // as-is; dismissing here would silently unblock a PR whose checks never
+    // actually completed.
     core.warning(
       `Made for ESPHome run did not produce a pass (status: ${status ?? "missing"}); ` +
-        "leaving any existing review untouched."
+        "leaving any existing review/comment untouched."
     );
-  } else if (active.length) {
-    // Genuine pass (or the page is no longer made-for-esphome): dismiss every
-    // active review so the PR is unblocked.
-    for (const r of active) {
-      await github.rest.pulls.dismissReview({
-        ...common,
-        review_id: r.id,
-        message:
-          "Made for ESPHome checks now pass (or the page is no longer " +
-          "made-for-esphome) — dismissing.",
-      });
-    }
-    core.info(`Dismissed ${active.length} review(s) on PR #${prNumber}.`);
-  } else {
-    core.info("Checks pass and no active review; nothing to do.");
   }
 };

--- a/.github/scripts/mfe-review-feedback.cjs
+++ b/.github/scripts/mfe-review-feedback.cjs
@@ -116,7 +116,10 @@ module.exports = async ({ github, context, core }) => {
 
   if (status === "changes") {
     if (!reportBody) {
+      // The verdict is failures, so a stale "all pass" comment must go even if
+      // we can't (re)post the blocking review without the report body.
       core.warning("status is `changes` but no report was uploaded; leaving reviews untouched.");
+      await removePassComment();
       return;
     }
     const body = `${MARKER}\n${reportBody}`;

--- a/scripts/review-made-for-esphome.test.ts
+++ b/scripts/review-made-for-esphome.test.ts
@@ -508,6 +508,26 @@ test("buildReport neutralizes @mentions from fork-controlled text", () => {
   assert.ok(!/@evil/.test(report), "raw @mention must be neutralized");
 });
 
+test("buildReport uses a green header when nothing blocks", () => {
+  const report = buildReport([
+    {
+      page: "src/docs/devices/Foo/index.md",
+      url: "https://github.com/o/r/blob/main/x.yaml",
+      fenceMissing: false,
+      fatalError: null,
+      configOk: true,
+      configInconclusive: false,
+      configError: null,
+      compile: "PASS",
+      compileLog: null,
+      checks: [{ item: "ESP32", status: "OK", detail: "ok" }],
+    },
+  ]);
+  assert.ok(report.includes("## ✅ Made for ESPHome review"));
+  assert.ok(report.includes("All automated Made for ESPHome checks pass"));
+  assert.ok(!report.includes("❌"));
+});
+
 test("buildReport escapes pipes/backslashes/newlines in checklist detail", () => {
   const report = buildReport([
     {

--- a/scripts/review-made-for-esphome.ts
+++ b/scripts/review-made-for-esphome.ts
@@ -1476,18 +1476,30 @@ function renderPage(r: PageResult): string {
 function buildReport(pages: PageResult[]): string {
   const blocking = pages.filter(pageBlocks);
   const lines: string[] = [];
-  lines.push("## ❌ Made for ESPHome review");
-  lines.push("");
-  lines.push(
-    `The automated Made for ESPHome checks found blocking issues on ` +
-      `**${blocking.length} page${blocking.length === 1 ? "" : "s"}**. ` +
-      "Each page below was compiled from its linked upstream config with only " +
-      "placeholder Wi-Fi secrets, then checked against the " +
-      `[Made for ESPHome checklist](${CHECKLIST_URL}). ` +
-      "Address the items marked ❌ and push an update — this review refreshes " +
-      "automatically and is dismissed once the checks pass. Items marked ⚠️ " +
-      "need a human to confirm (e.g. whether the hardware has a USB port)."
-  );
+  if (blocking.length === 0) {
+    lines.push("## ✅ Made for ESPHome review");
+    lines.push("");
+    lines.push(
+      "All automated Made for ESPHome checks pass. Each page below was compiled " +
+        "from its linked upstream config with only placeholder Wi-Fi secrets, " +
+        `then checked against the [Made for ESPHome checklist](${CHECKLIST_URL}). ` +
+        "A maintainer will take a final look before approval. Items marked ⚠️ " +
+        "still need a human to confirm (e.g. whether the hardware has a USB port)."
+    );
+  } else {
+    lines.push("## ❌ Made for ESPHome review");
+    lines.push("");
+    lines.push(
+      `The automated Made for ESPHome checks found blocking issues on ` +
+        `**${blocking.length} page${blocking.length === 1 ? "" : "s"}**. ` +
+        "Each page below was compiled from its linked upstream config with only " +
+        "placeholder Wi-Fi secrets, then checked against the " +
+        `[Made for ESPHome checklist](${CHECKLIST_URL}). ` +
+        "Address the items marked ❌ and push an update — this review refreshes " +
+        "automatically and is dismissed once the checks pass. Items marked ⚠️ " +
+        "need a human to confirm (e.g. whether the hardware has a USB port)."
+    );
+  }
   lines.push("");
   // Only the per-page content derives from fork-controlled input (URLs, slugs,
   // details), so neutralize @mentions there; the trusted intro/footer are left
@@ -1667,7 +1679,15 @@ async function main(): Promise<void> {
     console.log("\nNo blocking findings, but the run was inconclusive.");
     writeStatus("inconclusive");
   } else {
-    console.log("\nAll made-for-esphome checks pass — no report emitted.");
+    // All checks pass: still emit the (all-green) report so the feedback
+    // workflow can post it as a non-blocking acknowledgement comment.
+    const report = buildReport(results);
+    if (reportPath) {
+      fs.writeFileSync(reportPath, report, "utf8");
+      console.log("\nAll made-for-esphome checks pass — wrote green report.");
+    } else {
+      console.log("\n" + report);
+    }
     writeStatus("pass");
   }
 }

--- a/scripts/workflow-scripts.test.ts
+++ b/scripts/workflow-scripts.test.ts
@@ -31,6 +31,7 @@ function makeGithub(opts: {
   permission?: string; // legacy `permission` field
   roleName?: string; // granular `role_name` field
   permissionError?: boolean; // getCollaboratorPermissionLevel throws
+  comments?: unknown[]; // issue comments for paginate(listComments)
 } = {}) {
   const calls: Call[] = [];
   const record =
@@ -39,8 +40,12 @@ function makeGithub(opts: {
       calls.push({ method, args });
       return { data: {} };
     };
+  // Tag the list functions so paginate can dispatch reviews vs comments.
+  const listReviews = Object.assign(() => {}, { _kind: "reviews" });
+  const listComments = Object.assign(() => {}, { _kind: "comments" });
   const github = {
-    paginate: async () => opts.reviews ?? [],
+    paginate: async (fn: { _kind?: string }) =>
+      fn && fn._kind === "comments" ? opts.comments ?? [] : opts.reviews ?? [],
     rest: {
       repos: {
         getCollaboratorPermissionLevel: async (args: unknown) => {
@@ -55,7 +60,7 @@ function makeGithub(opts: {
         },
       },
       pulls: {
-        listReviews: () => {},
+        listReviews,
         createReview: record("createReview"),
         updateReview: record("updateReview"),
         dismissReview: record("dismissReview"),
@@ -79,7 +84,10 @@ function makeGithub(opts: {
         },
       },
       issues: {
+        listComments,
         createComment: record("createComment"),
+        updateComment: record("updateComment"),
+        deleteComment: record("deleteComment"),
       },
     },
   };
@@ -121,9 +129,10 @@ function withArtifact(
 
 const MARKER = "<!-- made-for-esphome-review -->";
 const SUPERSEDED = "<!-- mfe-superseded -->";
+const MARKER_PASS = "<!-- made-for-esphome-pass -->";
 
-test("feedback: report + no existing review -> creates a REQUEST_CHANGES review", async () => {
-  withArtifact("42", "## report body");
+test("feedback: changes + no existing review -> creates a REQUEST_CHANGES review", async () => {
+  withArtifact("42", "## report body", "changes");
   const { github, calls } = makeGithub({ reviews: [] });
   await feedbackScript({ github, context, core: freshCore() });
   const created = calls.filter((c) => c.method === "createReview");
@@ -136,7 +145,7 @@ test("feedback: report + no existing review -> creates a REQUEST_CHANGES review"
 });
 
 test("feedback: identical existing review -> no-op", async () => {
-  withArtifact("42", "## report body");
+  withArtifact("42", "## report body", "changes");
   const body = `${MARKER}\n## report body`;
   const { github, calls } = makeGithub({
     reviews: [{ id: 1, state: "CHANGES_REQUESTED", body }],
@@ -148,7 +157,7 @@ test("feedback: identical existing review -> no-op", async () => {
 });
 
 test("feedback: changed report -> supersedes old and posts new", async () => {
-  withArtifact("7", "## new body");
+  withArtifact("7", "## new body", "changes");
   const { github, calls } = makeGithub({
     reviews: [
       { id: 9, state: "CHANGES_REQUESTED", body: `${MARKER}\n## old body` },
@@ -166,7 +175,7 @@ test("feedback: changed report -> supersedes old and posts new", async () => {
 });
 
 test("feedback: superseded/other-bot reviews are ignored", async () => {
-  withArtifact("7", "## body");
+  withArtifact("7", "## body", "changes");
   const { github, calls } = makeGithub({
     reviews: [
       { id: 1, state: "CHANGES_REQUESTED", body: `${MARKER}\n${SUPERSEDED}\nstub` },
@@ -181,23 +190,67 @@ test("feedback: superseded/other-bot reviews are ignored", async () => {
   assert.equal(calls.filter((c) => c.method === "createReview").length, 1);
 });
 
-test("feedback: no report + pass status + active review -> dismiss", async () => {
-  withArtifact("7", null, "pass");
+test("feedback: changes clears a stale pass comment", async () => {
+  withArtifact("7", "## body", "changes");
+  const { github, calls } = makeGithub({
+    reviews: [],
+    comments: [{ id: 88, body: `${MARKER_PASS}\nall good` }],
+  });
+  await feedbackScript({ github, context, core: freshCore() });
+  assert.equal(calls.filter((c) => c.method === "createReview").length, 1);
+  const del = calls.filter((c) => c.method === "deleteComment");
+  assert.equal(del.length, 1);
+  assert.equal((del[0].args as { comment_id: number }).comment_id, 88);
+});
+
+test("feedback: pass -> dismiss active review and post the green comment", async () => {
+  withArtifact("7", "## ✅ all green", "pass");
   const { github, calls } = makeGithub({
     reviews: [{ id: 5, state: "CHANGES_REQUESTED", body: `${MARKER}\nx` }],
+    comments: [],
   });
   await feedbackScript({ github, context, core: freshCore() });
   assert.equal(calls.filter((c) => c.method === "dismissReview").length, 1);
-  assert.equal(calls.filter((c) => c.method === "createReview").length, 0);
+  const created = calls.filter((c) => c.method === "createComment");
+  assert.equal(created.length, 1);
+  const body = (created[0].args as { body: string }).body;
+  assert.ok(body.startsWith(MARKER_PASS));
+  assert.ok(body.includes("## ✅ all green"));
 });
 
-test("feedback: no-mfe status + active review -> dismiss", async () => {
+test("feedback: pass with identical existing comment -> no rewrite", async () => {
+  withArtifact("7", "## ✅ all green", "pass");
+  const { github, calls } = makeGithub({
+    reviews: [],
+    comments: [{ id: 3, body: `${MARKER_PASS}\n## ✅ all green` }],
+  });
+  await feedbackScript({ github, context, core: freshCore() });
+  assert.equal(calls.filter((c) => c.method === "createComment").length, 0);
+  assert.equal(calls.filter((c) => c.method === "updateComment").length, 0);
+});
+
+test("feedback: pass with changed comment -> update in place", async () => {
+  withArtifact("7", "## ✅ new green", "pass");
+  const { github, calls } = makeGithub({
+    reviews: [],
+    comments: [{ id: 3, body: `${MARKER_PASS}\n## ✅ old green` }],
+  });
+  await feedbackScript({ github, context, core: freshCore() });
+  const upd = calls.filter((c) => c.method === "updateComment");
+  assert.equal(upd.length, 1);
+  assert.equal((upd[0].args as { comment_id: number }).comment_id, 3);
+  assert.equal(calls.filter((c) => c.method === "createComment").length, 0);
+});
+
+test("feedback: no-mfe -> dismiss active review and remove pass comment", async () => {
   withArtifact("7", null, "no-mfe");
   const { github, calls } = makeGithub({
     reviews: [{ id: 5, state: "CHANGES_REQUESTED", body: `${MARKER}\nx` }],
+    comments: [{ id: 9, body: `${MARKER_PASS}\ngreen` }],
   });
   await feedbackScript({ github, context, core: freshCore() });
   assert.equal(calls.filter((c) => c.method === "dismissReview").length, 1);
+  assert.equal(calls.filter((c) => c.method === "deleteComment").length, 1);
 });
 
 test("feedback: inconclusive status does NOT dismiss the blocking review", async () => {
@@ -208,6 +261,7 @@ test("feedback: inconclusive status does NOT dismiss the blocking review", async
   const c = freshCore();
   await feedbackScript({ github, context, core: c });
   assert.equal(calls.filter((c) => c.method === "dismissReview").length, 0);
+  assert.equal(calls.filter((c) => c.method === "createComment").length, 0);
   assert.equal(c._warned.length, 1);
 });
 
@@ -222,15 +276,8 @@ test("feedback: crashed run (no status file) does NOT dismiss", async () => {
   assert.equal(c._warned.length, 1);
 });
 
-test("feedback: no report + pass status + no active review -> nothing", async () => {
-  withArtifact("7", null, "pass");
-  const { github, calls } = makeGithub({ reviews: [] });
-  await feedbackScript({ github, context, core: freshCore() });
-  assert.equal(calls.length, 0);
-});
-
 test("feedback: unreadable PR number -> setFailed", async () => {
-  withArtifact("not-a-number", "## body");
+  withArtifact("not-a-number", "## body", "changes");
   const { github, calls } = makeGithub({ reviews: [] });
   const c = freshCore();
   await feedbackScript({ github, context, core: c });

--- a/scripts/workflow-scripts.test.ts
+++ b/scripts/workflow-scripts.test.ts
@@ -203,6 +203,21 @@ test("feedback: changes clears a stale pass comment", async () => {
   assert.equal((del[0].args as { comment_id: number }).comment_id, 88);
 });
 
+test("feedback: changes with no report still removes a stale pass comment", async () => {
+  withArtifact("7", null, "changes"); // status changes but report missing
+  const { github, calls } = makeGithub({
+    reviews: [{ id: 5, state: "CHANGES_REQUESTED", body: `${MARKER}\nx` }],
+    comments: [{ id: 88, body: `${MARKER_PASS}\nall good` }],
+  });
+  const c = freshCore();
+  await feedbackScript({ github, context, core: c });
+  // No report -> don't touch the review, but still clear the contradictory ✅ comment.
+  assert.equal(calls.filter((x) => x.method === "createReview").length, 0);
+  assert.equal(calls.filter((x) => x.method === "dismissReview").length, 0);
+  assert.equal(calls.filter((x) => x.method === "deleteComment").length, 1);
+  assert.equal(c._warned.length, 1);
+});
+
 test("feedback: pass -> dismiss active review and post the green comment", async () => {
   withArtifact("7", "## ✅ all green", "pass");
   const { github, calls } = makeGithub({


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Follow-up to #1755. When a Made for ESPHome PR passes every automated check, the bot now posts the full green checklist as a non-blocking acknowledgement instead of staying silent. Previously a passing PR only had its blocking review dismissed, with no positive comment.

The acknowledgement is a plain issue comment keyed by its own hidden marker (`<!-- made-for-esphome-pass -->`), so it is upserted rather than duplicated: an unchanged run leaves it as-is, a changed run edits it in place. A run that finds issues removes any stale pass comment so the PR never shows a contradictory "all pass" note under a request-changes review, and a page that is no longer made-for-esphome removes it too. It is only ever a comment — never an approval.

To support this the review script now emits the report on a pass as well (with a green `## ✅` header), and the feedback workflow decides what to do from the explicit `mfe-status.txt` verdict (`pass` / `changes` / `inconclusive` / `no-mfe`) rather than from whether a report file exists. The earlier safety behaviour is unchanged: an inconclusive or crashed run still never dismisses a blocking review. The pass comment uses the existing `issues:*` scope the app already has (same one `made-for-esphome.yml` uses for labels), so no new permissions are required.

Covered by the existing `npm test` suite (46 unit tests plus 2 opt-in live network tests): the green-header report, and the full feedback lifecycle (pass posts/updates/skips the comment, a failing run deletes a stale pass comment, no-mfe removes it, and inconclusive/crashed runs touch nothing).

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [ ] The first `file=` fence on the page references `config.yaml`.
- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->