### PR TITLE
Update Zemismart Switch TB22

### DIFF
--- a/src/docs/devices/Zemismart-Switch-TB22/config.yaml
+++ b/src/docs/devices/Zemismart-Switch-TB22/config.yaml
@@ -1,0 +1,67 @@
+substitutions:
+  node_id: switch-living
+  verbose_name: "Switch Living"
+
+  switch_restore_mode: ALWAYS_OFF
+  switch1_name: Lamp 1
+  switch2_name: Lamp 2
+  switch3_name: Lamp 3
+
+esphome:
+
+esp8266:
+  board: esp01_1m
+
+binary_sensor:
+  - platform: gpio
+    id: button1
+    pin:
+      number: GPIO16
+      inverted: true
+    on_click:
+      - switch.toggle: relay1
+
+  - platform: gpio
+    id: button2
+    pin:
+      number: GPIO5
+      inverted: true
+      mode: INPUT_PULLUP
+    on_click:
+      - switch.toggle: relay2
+
+  - platform: gpio
+    id: button3
+    pin:
+      number: GPIO4
+      inverted: true
+      mode: INPUT_PULLUP
+    on_click:
+      - switch.toggle: relay3
+
+switch:
+  - platform: gpio
+    name: ${switch1_name}
+    pin: GPIO13
+    id: relay1
+    restore_mode: ${switch_restore_mode}
+  - platform: gpio
+    name: ${switch2_name}
+    pin: GPIO12
+    id: relay2
+    restore_mode: ${switch_restore_mode}
+  - platform: gpio
+    name: ${switch3_name}
+    pin: GPIO14
+    id: relay3
+    restore_mode: ${switch_restore_mode}
+
+light:
+  - platform: status_led
+    id: led_green
+    name: ${verbose_name} Backlight
+    restore_mode: ALWAYS_ON
+    entity_category: config
+    pin:
+      number: GPIO0
+      inverted: true

--- a/src/docs/devices/Zemismart-Switch-TB22/config.yaml
+++ b/src/docs/devices/Zemismart-Switch-TB22/config.yaml
@@ -8,7 +8,9 @@ substitutions:
   switch3_name: Lamp 3
 
 esphome:
-
+  name: ${node_id}
+  friendly_name: ${verbose_name}
+  
 esp8266:
   board: esp01_1m
 

--- a/src/docs/devices/Zemismart-Switch-TB22/config.yaml
+++ b/src/docs/devices/Zemismart-Switch-TB22/config.yaml
@@ -10,7 +10,7 @@ substitutions:
 esphome:
   name: ${node_id}
   friendly_name: ${verbose_name}
-  
+
 esp8266:
   board: esp01_1m
 

--- a/src/docs/devices/Zemismart-Switch-TB22/index.md
+++ b/src/docs/devices/Zemismart-Switch-TB22/index.md
@@ -12,7 +12,7 @@ This switch comes in three variants with 1 to 3 gangs (TB21, TB22, TB23).
 They all use the same config, you just drop the extra relays/inputs
 
 Manufacturer:
-[Zemismart](https://www.zemismart.com/products/zemismart-tb21-smart-wifi-luxury-wall-light-switch-1-2-3-gangs-compatible-with-smart-life-app-alexa-google-home-voice-control)
+[Zemismart](https://www.zemismart.com/products/tb21)
 
 ## How to flash
 
@@ -38,74 +38,5 @@ Use this image to map the right connectors.
 The green leds are used as status light and also as backlight, when the gang is off.
 It can be controlled to be always off.
 
-```yaml
-substitutions:
-  node_id: switch-living
-  verbose_name: "Switch Living"
-
-  switch_restore_mode: ALWAYS_OFF
-  switch1_name: Lamp 1
-  switch2_name: Lamp 2
-  switch3_name: Lamp 3
-
-#####
-
-esphome:
-
-esp8266:
-  board: esp01_1m
-
-binary_sensor:
-  - platform: gpio
-    id: button1
-    pin:
-      number: GPIO16
-      inverted: true
-    on_click:
-      - switch.toggle: relay1
-
-  - platform: gpio
-    id: button2
-    pin:
-      number: GPIO5
-      inverted: true
-      mode: INPUT_PULLUP
-    on_click:
-      - switch.toggle: relay2
-
-  - platform: gpio
-    id: button3
-    pin:
-      number: GPIO4
-      inverted: true
-      mode: INPUT_PULLUP
-    on_click:
-      - switch.toggle: relay3
-
-switch:
-  - platform: gpio
-    name: ${switch1_name}
-    pin: GPIO13
-    id: relay1
-    restore_mode: ${switch_restore_mode}
-  - platform: gpio
-    name: ${switch2_name}
-    pin: GPIO12
-    id: relay2
-    restore_mode: ${switch_restore_mode}
-  - platform: gpio
-    name: ${switch3_name}
-    pin: GPIO14
-    id: relay3
-    restore_mode: ${switch_restore_mode}
-
-light:
-  - platform: status_led
-    id: led_green
-    name: ${verbose_name} Backlight
-    restore_mode: ALWAYS_ON
-    entity_category: config
-    pin:
-      number: GPIO0
-      inverted: true
+```yaml file=config.yaml
 ```


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

* Extracted config.yaml
* Fixed [broken link](https://github.com/esphome/devices.esphome.io/issues/1576)

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [X] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [X] The first `file=` fence on the page references `config.yaml`.
- [X] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [X] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
