### PR TITLE
Update Zemismart 6W A19 Bulb

### DIFF
--- a/src/docs/devices/Zemismart-Bulb-A19/config.yaml
+++ b/src/docs/devices/Zemismart-Bulb-A19/config.yaml
@@ -46,15 +46,3 @@ light:
     green: output_green
     blue: output_blue
     white: output_white
-
-sensor:
-  - platform: wifi_signal
-    name: "${dev_name}_wifi_signal"
-    update_interval: 30s
-  - platform: uptime
-    name: "${dev_name}_uptime"
-    update_interval: 120s
-
-text_sensor:
-  - platform: version
-    name: "${dev_name}_version"

--- a/src/docs/devices/Zemismart-Bulb-A19/config.yaml
+++ b/src/docs/devices/Zemismart-Bulb-A19/config.yaml
@@ -1,0 +1,60 @@
+substitutions:
+  dev_name: zemismart_bulb_a19_001
+
+esphome:
+  name: ${dev_name}
+
+esp8266:
+  board: esp01_1m
+
+# Enable logging
+logger:
+
+switch:
+  - platform: shutdown
+    name: "${dev_name}_shutdown"
+  - platform: restart
+    name: "${dev_name}_restart"
+
+my9231:
+  data_pin: GPIO13
+  clock_pin: GPIO15
+  num_channels: 4
+  num_chips: 1
+
+output:
+  - platform: my9231
+    id: output_white
+    channel: 0
+  - platform: my9231
+    id: output_blue
+    channel: 1
+  - platform: my9231
+    id: output_green
+    channel: 2
+  - platform: my9231
+    id: output_red
+    channel: 3
+
+light:
+  - platform: rgbw
+    id: light_01
+    name: "${dev_name}_light"
+    default_transition_length: 0s
+    restore_mode: ALWAYS_ON #Start with light on after reboot/power-loss event, so that it works from a dumb lightswitch
+    red: output_red
+    green: output_green
+    blue: output_blue
+    white: output_white
+
+sensor:
+  - platform: wifi_signal
+    name: "${dev_name}_wifi_signal"
+    update_interval: 30s
+  - platform: uptime
+    name: "${dev_name}_uptime"
+    update_interval: 120s
+
+text_sensor:
+  - platform: version
+    name: "${dev_name}_version"

--- a/src/docs/devices/Zemismart-Bulb-A19/index.md
+++ b/src/docs/devices/Zemismart-Bulb-A19/index.md
@@ -2,12 +2,14 @@
 title: Zemismart 6W A19 Bulb
 date-published: 2019-11-26
 type: light
-standard: eu
+standard: global
 board: esp8266
 ---
 
 RGBW smart light bulb, A19 shape, E27 base, RGB colors + cold white, 100-240V AC 50/60Hz, natively Tuya/Smart Life,
 works with Tuya-convert to flash to ESPHome.
+
+[Manufacturer](https://www.zemismart.com/) (Model no longer listed)
 
 ## GPIO Pinout
 
@@ -18,72 +20,5 @@ works with Tuya-convert to flash to ESPHome.
 
 ## Basic Configuration
 
-```yaml
-#https://www.zemismart.com/zemismart-e27-6w-wifi-rgbw-led-bulb-light-compatible-with-echo-alexa-google-home-remote-control-by-ios-amp-android-app-with-feedback-white-color-p0040-p0040.html
-substitutions:
-  dev_name: zemismart_bulb_a19_001
-
-esphome:
-  name: ${dev_name}
-
-esp8266:
-  board: esp01_1m
-
-wifi:
-
-# Enable logging
-logger:
-
-api:
-
-ota:
-
-switch:
-  - platform: shutdown
-    name: "${dev_name}_shutdown"
-  - platform: restart
-    name: "${dev_name}_restart"
-
-my9231:
-  data_pin: GPIO13
-  clock_pin: GPIO15
-  num_channels: 4
-  num_chips: 1
-
-output:
-  - platform: my9231
-    id: output_white
-    channel: 0
-  - platform: my9231
-    id: output_blue
-    channel: 1
-  - platform: my9231
-    id: output_green
-    channel: 2
-  - platform: my9231
-    id: output_red
-    channel: 3
-
-light:
-  - platform: rgbw
-    id: light_01
-    name: "${dev_name}_light"
-    default_transition_length: 0s
-    restore_mode: ALWAYS_ON #Start with light on after reboot/power-loss event, so that it works from a dumb lightswitch
-    red: output_red
-    green: output_green
-    blue: output_blue
-    white: output_white
-
-sensor:
-  - platform: wifi_signal
-    name: "${dev_name}_wifi_signal"
-    update_interval: 30s
-  - platform: uptime
-    name: "${dev_name}_uptime"
-    update_interval: 120s
-
-text_sensor:
-  - platform: version
-    name: "${dev_name}_version"
+```yaml file=config.yaml
 ```


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

* extracted config.xaml
* removed [broken link](https://github.com/esphome/devices.esphome.io/issues/1576)

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [X] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [X] The first `file=` fence on the page references `config.yaml`.
- [X] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [X] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
