### PR TITLE
Update Athom E27 7W Bulb

### DIFF
--- a/src/docs/devices/Athom-E27-7W-Bulb/config.yaml
+++ b/src/docs/devices/Athom-E27-7W-Bulb/config.yaml
@@ -10,19 +10,6 @@ esp8266:
 
 logger:
 
-binary_sensor:
-  - platform: status
-    name: "${friendly_name} Status"
-
-sensor:
-  - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
-
-switch:
-  - platform: restart
-    id: restart_switch
-    name: "${friendly_name} Restart"
-
 output:
   - platform: esp8266_pwm
     id: red_output

--- a/src/docs/devices/Athom-E27-7W-Bulb/config.yaml
+++ b/src/docs/devices/Athom-E27-7W-Bulb/config.yaml
@@ -1,18 +1,14 @@
 substitutions:
   device_name: "athom-rgbww-light"
   friendly_name: "Athom RGBWW Light"
-  project_name: "athom.rgbww-light"
-  project_version: "1.0"
 
 esphome:
   name: "${device_name}"
-  name_add_mac_suffix: true
-  project:
-    name: "${project_name}"
-    version: "${project_version}"
 
 esp8266:
   board: esp8285
+
+logger:
 
 binary_sensor:
   - platform: status

--- a/src/docs/devices/Athom-E27-7W-Bulb/config.yaml
+++ b/src/docs/devices/Athom-E27-7W-Bulb/config.yaml
@@ -1,0 +1,57 @@
+substitutions:
+  device_name: "athom-rgbww-light"
+  friendly_name: "Athom RGBWW Light"
+  project_name: "athom.rgbww-light"
+  project_version: "1.0"
+
+esphome:
+  name: "${device_name}"
+  name_add_mac_suffix: true
+  project:
+    name: "${project_name}"
+    version: "${project_version}"
+
+esp8266:
+  board: esp8285
+
+binary_sensor:
+  - platform: status
+    name: "${friendly_name} Status"
+
+sensor:
+  - platform: uptime
+    name: "${friendly_name} Uptime Sensor"
+
+switch:
+  - platform: restart
+    id: restart_switch
+    name: "${friendly_name} Restart"
+
+output:
+  - platform: esp8266_pwm
+    id: red_output
+    pin: GPIO4
+  - platform: esp8266_pwm
+    id: green_output
+    pin: GPIO12
+  - platform: esp8266_pwm
+    id: blue_output
+    pin: GPIO14
+  - platform: esp8266_pwm
+    id: warm_white_output
+    pin: GPIO13
+  - platform: esp8266_pwm
+    id: white_output
+    pin: GPIO5
+
+light:
+  - platform: rgbww
+    name: "${friendly_name}"
+    red: red_output
+    green: green_output
+    blue: blue_output
+    warm_white: warm_white_output
+    cold_white: white_output
+    cold_white_color_temperature: 6000 K
+    warm_white_color_temperature: 3000 K
+    color_interlock: true

--- a/src/docs/devices/Athom-E27-7W-Bulb/index.md
+++ b/src/docs/devices/Athom-E27-7W-Bulb/index.md
@@ -2,17 +2,17 @@
 title: Athom E27 7W Bulb
 date-published: 2021-10-05
 type: light
-standard: us
+standard: global
 board: esp8266
 ---
-
-Manufacturer: [Athom.tech](https://www.athom.tech/blank-1/7w-2-pack)
 
 ## Flashing Procedure
 
 Natively runs Tasmota, upload ESPHome binary to flash wirelessly.
 
 ## Bulb Specifications
+
+Manufacturer: [Athom.tech](https://www.athom.tech/)
 
 Color: RGB+Warm+Cold White
 Color Temperature: 3000-6000K
@@ -37,84 +37,5 @@ Base: E27
 
 ## Basic Configuration
 
-```yaml
-substitutions:
-  device_name: "athom-rgbww-light"
-  friendly_name: "Athom RGBWW Light"
-  project_name: "athom.rgbww-light"
-  project_version: "1.0"
-
-esphome:
-  name: "${device_name}"
-  name_add_mac_suffix: true
-  project:
-    name: "${project_name}"
-    version: "${project_version}"
-
-esp8266:
-  board: esp8285
-
-api:
-
-ota:
-
-logger:
-
-web_server:
-  port: 80
-
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-  ap:
-
-captive_portal:
-
-binary_sensor:
-  - platform: status
-    name: "${friendly_name} Status"
-
-sensor:
-  - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
-
-switch:
-  - platform: restart
-    id: restart_switch
-    name: "${friendly_name} Restart"
-
-output:
-  - platform: esp8266_pwm
-    id: red_output
-    pin: GPIO4
-  - platform: esp8266_pwm
-    id: green_output
-    pin: GPIO12
-  - platform: esp8266_pwm
-    id: blue_output
-    pin: GPIO14
-  - platform: esp8266_pwm
-    id: warm_white_output
-    pin: GPIO13
-  - platform: esp8266_pwm
-    id: white_output
-    pin: GPIO5
-
-light:
-  - platform: rgbww
-    name: "${friendly_name}"
-    red: red_output
-    green: green_output
-    blue: blue_output
-    warm_white: warm_white_output
-    cold_white: white_output
-    cold_white_color_temperature: 6000 K
-    warm_white_color_temperature: 3000 K
-    color_interlock: true
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "${friendly_name} IP Address"
-      disabled_by_default: true
+```yaml file=config.yaml
 ```


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

* Update [broken link](https://github.com/esphome/devices.esphome.io/issues/1576)
* Extract config.yaml

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [X] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [X] The first `file=` fence on the page references `config.yaml`.
- [X] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [X] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
