### PR TITLE
Update KinCony KC868-Uair

### DIFF
--- a/src/docs/devices/KinCony-KC868-Uair/config.yaml
+++ b/src/docs/devices/KinCony-KC868-Uair/config.yaml
@@ -18,8 +18,9 @@ i2c:
 
 # Example configuration entry
 one_wire:
-  - pin: GPIO27
-    update_interval: 15s
+  - platform: gpio
+    id: one_wire_gpio_1
+    pin: GPIO27
 
 # Individual sensors
 sensor:

--- a/src/docs/devices/KinCony-KC868-Uair/config.yaml
+++ b/src/docs/devices/KinCony-KC868-Uair/config.yaml
@@ -1,6 +1,6 @@
 # Basic Config
 esphome:
-  name: KC868-Uair
+  name: kc868-uair
 
 esp32:
   variant: esp32

--- a/src/docs/devices/KinCony-KC868-Uair/config.yaml
+++ b/src/docs/devices/KinCony-KC868-Uair/config.yaml
@@ -1,0 +1,68 @@
+# Basic Config
+esphome:
+  name: KC868-Uair
+
+esp32:
+  variant: esp32
+  framework:
+    type: arduino
+
+# Enable logging
+logger:
+
+i2c:
+  sda: 4
+  scl: 16
+  scan: true
+  id: bus_a
+
+# Example configuration entry
+one_wire:
+  - pin: GPIO27
+    update_interval: 15s
+
+# Individual sensors
+sensor:
+  - platform: dallas_temp
+    address: 0xC000000004D81528
+    name: "internal Temperature"
+
+  # Example configuration entry
+  - platform: sht3xd
+    temperature:
+      name: "extend Temperature"
+    humidity:
+      name: "extend Humidity"
+    address: 0x44
+    update_interval: 15s
+
+light:
+  - platform: esp32_rmt_led_strip
+    chipset: ws2812
+    pin: GPIO32 # Pin Define connected with LED strip
+    num_leds: 4 #LEDs number
+    rgb_order: GRB
+    name: "Uair-Bottom-LED"
+    effects:
+      - addressable_rainbow: ##defined 7 effects styles
+      - addressable_color_wipe:
+      - addressable_scan:
+      - addressable_twinkle:
+      - addressable_random_twinkle:
+      - addressable_fireworks:
+      - addressable_flicker:
+
+  - platform: esp32_rmt_led_strip
+    chipset: ws2812
+    pin: GPIO33 # Pin Define connected with LED strip
+    num_leds: 1 #LEDs number
+    rgb_order: RGB
+    name: "Uair-VVertical-LED"
+    effects:
+      - addressable_rainbow: ##defined 7 effects styles
+      - addressable_color_wipe:
+      - addressable_scan:
+      - addressable_twinkle:
+      - addressable_random_twinkle:
+      - addressable_fireworks:
+      - addressable_flicker:

--- a/src/docs/devices/KinCony-KC868-Uair/index.md
+++ b/src/docs/devices/KinCony-KC868-Uair/index.md
@@ -6,6 +6,8 @@ standard: global
 board: esp32
 ---
 
+## Product Images
+
 ![Product](kc868-uair.jpg "Product Image")
 
 ## GPIO Pinout
@@ -35,82 +37,9 @@ board: esp32
 | GPIO39 | Free GPIO                   |
 | GPIO35 | Free GPIO                   |
 
-[Additional pinout/design details](https://www.kincony.com/esp32-wifi-temperatur)
+[Additional pinout/design details](https://www.kincony.com/kc868-uair-hardware-design-details.html)
 
 ## Basic Configuration
 
-```yaml
-# Basic Config
-esphome:
-  name: KC868-Uair
-
-esp32:
-  variant: esp32
-  framework:
-    type: arduino
-
-# Enable logging
-logger:
-
-# Enable Home Assistant API
-api:
-  encryption:
-    key: "hx8eSqbwjWs9/2bK0qK55QfTIOpI4gCfzLOeaOXZMaU="
-
-i2c:
-  sda: 4
-  scl: 16
-  scan: true
-  id: bus_a
-
-# Example configuration entry
-one_wire:
-  - pin: GPIO27
-    update_interval: 15s
-
-# Individual sensors
-sensor:
-  - platform: dallas_temp
-    address: 0xC000000004D81528
-    name: "internal Temperature"
-
-  # Example configuration entry
-  - platform: sht3xd
-    temperature:
-      name: "extend Temperature"
-    humidity:
-      name: "extend Humidity"
-    address: 0x44
-    update_interval: 15s
-
-light:
-  - platform: esp32_rmt_led_strip
-    chipset: ws2812
-    pin: GPIO32 # Pin Define connected with LED strip
-    num_leds: 4 #LEDs number
-    rgb_order: GRB
-    name: "Uair-Bottom-LED"
-    effects:
-      - addressable_rainbow: ##defined 7 effects styles
-      - addressable_color_wipe:
-      - addressable_scan:
-      - addressable_twinkle:
-      - addressable_random_twinkle:
-      - addressable_fireworks:
-      - addressable_flicker:
-
-  - platform: esp32_rmt_led_strip
-    chipset: ws2812
-    pin: GPIO33 # Pin Define connected with LED strip
-    num_leds: 1 #LEDs number
-    rgb_order: RGB
-    name: "Uair-VVertical-LED"
-    effects:
-      - addressable_rainbow: ##defined 7 effects styles
-      - addressable_color_wipe:
-      - addressable_scan:
-      - addressable_twinkle:
-      - addressable_random_twinkle:
-      - addressable_fireworks:
-      - addressable_flicker:
+```yaml file=config.yaml
 ```


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

* Update [broken link](KinCony KC868-Uair)
* Extract config.yaml

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [X] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [X] The first `file=` fence on the page references `config.yaml`.
- [X] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [X] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
