### PR TITLE
Update LSC Smart Connect Switch

### DIFF
--- a/src/docs/devices/LSC-Smart-Connect-Switch/config.yaml
+++ b/src/docs/devices/LSC-Smart-Connect-Switch/config.yaml
@@ -1,0 +1,48 @@
+substitutions:
+  plug_name: lsc-powerplug1
+
+esphome:
+  name: ${plug_name}
+
+esp8266:
+  board: esp01_1m
+
+logger:
+
+binary_sensor:
+  # Binary sensor for the button press
+  - platform: gpio
+    pin:
+      number: GPIO13
+      mode: INPUT_PULLUP
+      inverted: true
+    name: ${plug_name}_button
+    internal: true
+    on_press:
+      - switch.toggle: relay
+
+output:
+  # Relay state led
+  - platform: esp8266_pwm
+    id: state_led
+    pin:
+      number: GPIO4
+      inverted: true
+
+light:
+  # Relay state light
+  - platform: monochromatic
+    id: led
+    name: ${plug_name}_led
+    output: state_led
+
+switch:
+  # Switch toggles relay
+  - platform: gpio
+    id: relay
+    name: ${plug_name}_relay
+    pin: GPIO12
+    on_turn_on:
+      - light.turn_on: led
+    on_turn_off:
+      - light.turn_off: led

--- a/src/docs/devices/LSC-Smart-Connect-Switch/index.md
+++ b/src/docs/devices/LSC-Smart-Connect-Switch/index.md
@@ -13,6 +13,7 @@ The latest LSC Smart Connect Switch devices use the Tuya WB2S module, which is n
 ## Notice
 
 - This plug is flashable using the latest tuya-convert with a compiled ESPHome binary
+- There are several models that look similar but are technically very different!
 
 ## Product Images
 
@@ -29,65 +30,8 @@ The latest LSC Smart Connect Switch devices use the Tuya WB2S module, which is n
 
 ## Basic configuration
 
-```yml
-substitutions:
-  plug_name: lsc-powerplug1
-
-esphome:
-  name: ${plug_name}
-
-esp8266:
-  board: esp01_1m
-
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-
-api:
-logger:
-ota:
-
-binary_sensor:
-  # Binary sensor for the button press
-  - platform: status
-    name: ${plug_name}_status
-  - platform: gpio
-    pin:
-      number: GPIO13
-      mode: INPUT_PULLUP
-      inverted: true
-    name: ${plug_name}_button
-    internal: true
-    on_press:
-      - switch.toggle: relay
-
-output:
-  # Relay state led
-  - platform: esp8266_pwm
-    id: state_led
-    pin:
-      number: GPIO4
-      inverted: true
-
-light:
-  # Relay state light
-  - platform: monochromatic
-    id: led
-    name: ${plug_name}_led
-    output: state_led
-
-switch:
-  # Switch toggles relay
-  - platform: gpio
-    id: relay
-    name: ${plug_name}_relay
-    pin: GPIO12
-    on_turn_on:
-      - light.turn_on: led
-    on_turn_off:
-      - light.turn_off: led
+```yaml file=config.yaml
 ```
 
 [https://thibmaek.com/posts/flashing-esphome-to-lsc-smart-connect-action-switches-power-plugs](https://thibmaek.com/posts/flashing-esphome-to-lsc-smart-connect-action-switches-power-plugs)
 
-[Tasmota template LSC power plug](https://templates.blakadder.com/lsc_smart_connect_power_plug.html)

--- a/src/docs/devices/LSC-Smart-Connect-Switch/index.md
+++ b/src/docs/devices/LSC-Smart-Connect-Switch/index.md
@@ -34,4 +34,3 @@ The latest LSC Smart Connect Switch devices use the Tuya WB2S module, which is n
 ```
 
 [https://thibmaek.com/posts/flashing-esphome-to-lsc-smart-connect-action-switches-power-plugs](https://thibmaek.com/posts/flashing-esphome-to-lsc-smart-connect-action-switches-power-plugs)
-


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

* Remove [broken link](https://github.com/esphome/devices.esphome.io/issues/1576)
* Extract config.yaml

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [X] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [X] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [X] The first `file=` fence on the page references `config.yaml`.
- [X] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [X] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
