### PR TITLE
Add device M5Stack AtomS3R + Atomic Echo Base

### DIFF
--- a/src/docs/devices/M5Stack-AtomS3R-Echo-Base/config.yaml
+++ b/src/docs/devices/M5Stack-AtomS3R-Echo-Base/config.yaml
@@ -1,0 +1,112 @@
+substitutions:
+  name: atoms3r-echo-base
+  friendly_name: AtomS3R Echo Base
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendly_name}
+  min_version: 2026.1.0
+
+esp32:
+  board: m5stack-atoms3
+  flash_size: 8MB
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+  speed: 80MHz
+
+logger:
+  level: INFO
+  hardware_uart: USB_SERIAL_JTAG
+
+wifi:
+  # Fallback hotspot only — add your own ssid/password when you adopt this.
+  ap:
+
+# Two separate I2C buses. The AtomS3R's own peripherals sit on bsp_bus; the
+# Atomic Echo Base brings its own bus out on the base connector.
+i2c:
+  - id: bsp_bus
+    sda:
+      number: GPIO45
+      ignore_strapping_warning: true
+    scl:
+      number: GPIO0
+      ignore_strapping_warning: true
+    scan: true
+  - id: ext_bus
+    sda: GPIO38
+    scl: GPIO39
+    scan: true
+
+# GPIO expander on the Echo Base. The speaker amplifier enable line hangs off
+# this rather than off a native pin.
+pi4ioe5v6408:
+  - id: pi4ioe5v6408_hub
+    i2c_id: ext_bus
+    address: 0x43
+
+i2s_audio:
+  - id: i2s_audio_bus
+    i2s_lrclk_pin: GPIO6
+    i2s_bclk_pin: GPIO8
+    # No MCLK pin is wired on this base.
+
+audio_dac:
+  - platform: es8311
+    id: es8311_dac
+    i2c_id: ext_bus
+    bits_per_sample: 16bit
+    sample_rate: 48000
+    use_microphone: false
+    use_mclk: false
+
+microphone:
+  - platform: i2s_audio
+    id: i2s_mic
+    i2s_din_pin: GPIO7
+    adc_type: external
+    sample_rate: 16000
+    bits_per_sample: 16bit
+
+speaker:
+  - platform: i2s_audio
+    id: i2s_speaker
+    i2s_dout_pin: GPIO5
+    dac_type: external
+    audio_dac: es8311_dac
+    sample_rate: 48000
+    channel: left
+
+switch:
+  # NS4150B amplifier enable, via the Echo Base GPIO expander.
+  - platform: gpio
+    name: Speaker Enable
+    icon: mdi:volume-high
+    restore_mode: RESTORE_DEFAULT_ON
+    pin:
+      pi4ioe5v6408: pi4ioe5v6408_hub
+      number: 0
+      mode:
+        output: true
+
+binary_sensor:
+  - platform: gpio
+    id: user_button
+    name: Button
+    pin:
+      number: GPIO41
+      mode: INPUT_PULLUP
+      inverted: true
+
+media_player:
+  - platform: speaker
+    id: echo_base_player
+    name: ${friendly_name}
+    announcement_pipeline:
+      speaker: i2s_speaker
+      format: FLAC
+      sample_rate: 48000
+      num_channels: 1

--- a/src/docs/devices/M5Stack-AtomS3R-Echo-Base/index.md
+++ b/src/docs/devices/M5Stack-AtomS3R-Echo-Base/index.md
@@ -1,0 +1,60 @@
+---
+title: M5Stack AtomS3R + Atomic Echo Base
+date-published: 2026-08-12
+type: misc
+standard: global
+board: esp32
+difficulty: 2
+made-for-esphome: false
+project-url: https://github.com/gbroeckling/esphome-devices/tree/main/stack5echo-voice-assist
+---
+
+## Description
+
+The M5Stack AtomS3R is a 24&nbsp;mm ESP32-S3 module that stacks onto M5Stack's Atomic bases. Seated on the
+**Atomic Echo Base** it becomes a compact voice satellite that both hears and speaks from one board.
+
+- ESP32-S3 with 8&nbsp;MB flash and 8&nbsp;MB octal PSRAM
+- Atomic Echo Base carrying an ES8311 audio codec, an analog microphone and an NS4150B amplifier
+- PI4IOE5V6408 GPIO expander on the base at I²C `0x43` — the amplifier enable line hangs off this, not off a
+  native pin
+- Two separate I²C buses: the AtomS3R's own peripherals on one, the Echo Base on the other
+- LP5562 RGB LED and a BMI270 IMU on the AtomS3R itself
+- Programmable button on `GPIO41`, USB-C for power and flashing
+
+## Setup
+
+1. Seat the AtomS3R on the Atomic Echo Base and connect it over USB-C.
+2. Flash the configuration below.
+3. Adopt the device in Home Assistant and add it to a voice assistant pipeline.
+
+## Configuration
+
+Hardware only — the two I²C buses, the GPIO expander, the I²S bus, the ES8311 codec, microphone, speaker and
+media player. The ES8311 codec and the PI4IOE5V6408 expander are both supported natively, so this needs no
+external components.
+
+```yaml file=config.yaml
+```
+
+### Voice assistant
+
+```yaml file=voice-assistant.yaml
+```
+
+## Notes
+
+- **Build on ESPHome 2026.7.3 or newer.** The tflite runtime in some earlier releases cannot load current
+  microWakeWord models. It fails at boot with `Failed to allocate tensors for the streaming model`, the wake
+  engine stops, and nothing else reports a problem — the device connects, logs normally and answers the API, it
+  simply never hears you. Older versions flash and run perfectly happily, which is what makes this easy to miss;
+  mine sat in that state for months before I worked out what it was.
+- **Don't put a Bluetooth tracker or proxy on this board alongside the voice assistant.** BLE scanning starves
+  the audio pipeline. Removing it was half the fix when I was chasing the problem above.
+- The amplifier is disabled at boot until the **Speaker Enable** switch is turned on, which is why the
+  configuration sets `restore_mode: RESTORE_DEFAULT_ON`.
+- The onboard RGB LED is an LP5562, which is not a core ESPHome component. If you want it, M5Stack publish one at
+  `github://m5stack/esphome-yaml/components@main`. It is left out here so the configuration has no external
+  dependencies.
+- If you are reflashing a device that already carries a non-standard partition table, remember that OTA cannot
+  rewrite one — a layout change needs a USB flash.

--- a/src/docs/devices/M5Stack-AtomS3R-Echo-Base/voice-assistant.yaml
+++ b/src/docs/devices/M5Stack-AtomS3R-Echo-Base/voice-assistant.yaml
@@ -1,0 +1,40 @@
+# Voice assistant layer for the AtomS3R + Atomic Echo Base. Add this to the
+# hardware configuration. Requires ESPHome 2026.7.3 or newer — see the note
+# about microWakeWord on older releases.
+
+# voice_assistant talks to Home Assistant over the native API, so the component
+# has to be present here.
+api:
+
+micro_wake_word:
+  id: mww
+  microphone:
+    microphone: i2s_mic
+  models:
+    - model: github://esphome/micro-wake-word-models/models/v2/hey_jarvis.json
+  on_wake_word_detected:
+    - voice_assistant.start:
+        wake_word: !lambda return wake_word;
+
+voice_assistant:
+  microphone:
+    microphone: i2s_mic
+  media_player: echo_base_player
+  use_wake_word: false
+  noise_suppression_level: 2
+  auto_gain: 31dBFS
+  volume_multiplier: 2.0
+
+  on_client_connected:
+    - micro_wake_word.start:
+
+  on_end:
+    - wait_until:
+        condition:
+          media_player.is_idle:
+            id: echo_base_player
+        timeout: 30s
+    - micro_wake_word.start:
+
+  on_error:
+    - micro_wake_word.start:


### PR DESCRIPTION
Adds a device page for the M5Stack AtomS3R seated on the Atomic Echo Base, which had no page yet. Together they make a compact voice satellite that both hears and speaks from one board.

`config.yaml` is hardware only — the two I²C buses, the PI4IOE5V6408 GPIO expander on the base, the I²S bus, the ES8311 codec, microphone, speaker and media player. The ES8311 and the PI4IOE5V6408 are both core components now, so the configuration needs **no external components**. A separate `voice-assistant.yaml` adds microWakeWord and the Home Assistant voice pipeline.

Two things on the page are worth flagging because they cost me a lot of time:

- **microWakeWord needs 2026.7.3 or newer.** Older tflite runtimes cannot load current models. The wake engine stops at boot with `Failed to allocate tensors for the streaming model` and nothing else complains — the device connects, logs normally and answers the API, it just never hears you. Mine was in that state for months.
- **BLE scanning on this board starves the audio pipeline.** Removing a Bluetooth tracker was half the fix.

Both yaml files validate under ESPHome 2026.7.3 (`esphome config` → `Configuration is valid!`). `validate-devices` and `validate-yaml-configs` pass. No photo — I would rather leave the slot empty than use a stock product shot.