### PR TITLE
Do not check links that are code, not links

### DIFF
--- a/scripts/check-links.test.ts
+++ b/scripts/check-links.test.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env tsx
+/**
+ * Unit tests for the URL extraction in scripts/check-links.ts.
+ *
+ * Only `extractUrls` is covered - the network side needs no test here, and
+ * the part that produced false failures on the weekly report was always the
+ * extraction. Run with `npm test`.
+ *
+ * Fixtures use `esphome.io` and `vendor-site.dev` rather than `example.com`
+ * on purpose: `example.*` and `*.invalid` are in the SKIP list, so a fixture
+ * built from them would pass every fence test without the fence code ever
+ * running.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { extractUrls } from "./check-links.ts";
+
+let counter = 0;
+
+/** Write `body` to a scratch .md file and return the URLs extracted from it. */
+function urlsIn(body: string): string[] {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "check-links-"));
+  const file = path.join(dir, `fixture-${counter++}.md`);
+  fs.writeFileSync(file, body, "utf8");
+  try {
+    return [...extractUrls([file]).keys()].sort();
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("finds a link in prose", () => {
+  assert.deepEqual(urlsIn("See [the docs](https://esphome.io/docs) for more."), [
+    "https://esphome.io/docs",
+  ]);
+});
+
+test("reports the line a link is on", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "check-links-"));
+  const file = path.join(dir, "lines.md");
+  fs.writeFileSync(file, "# Title\n\ntext\n\nhttps://esphome.io/x\n", "utf8");
+  try {
+    assert.equal(extractUrls([file]).get("https://esphome.io/x")?.[0].line, 5);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("skips a URL inside a fenced code block", () => {
+  // The shape that generates most of the noise: a device page is mostly one
+  // YAML config block, and the URLs in it are placeholders or pinned citations.
+  assert.deepEqual(
+    urlsIn(
+      [
+        "Config:",
+        "",
+        "```yaml",
+        "# Basic config, see https://vendor-site.dev/product-page",
+        "sensor:",
+        "  - platform: rest",
+        "    resource: http://DEVICE_IP/json",
+        "```",
+      ].join("\n"),
+    ),
+    [],
+  );
+});
+
+test("resumes checking after a fenced block closes", () => {
+  assert.deepEqual(
+    urlsIn(
+      [
+        "```yaml",
+        "url: https://inside.vendor-site.dev/",
+        "```",
+        "",
+        "https://after.vendor-site.dev/",
+      ].join("\n"),
+    ),
+    ["https://after.vendor-site.dev/"],
+  );
+});
+
+test("a tilde fence is a fence too", () => {
+  assert.deepEqual(
+    urlsIn(["~~~", "https://inside.vendor-site.dev/", "~~~"].join("\n")),
+    [],
+  );
+});
+
+test("a backtick run inside a tilde fence does not close it", () => {
+  assert.deepEqual(
+    urlsIn(
+      ["~~~", "```", "https://inside.vendor-site.dev/", "```", "~~~"].join("\n"),
+    ),
+    [],
+  );
+});
+
+test("a shorter fence inside a longer one does not close it", () => {
+  // CommonMark: the closing fence must be at least as long as the opening one.
+  assert.deepEqual(
+    urlsIn(
+      ["````", "```", "https://inside.vendor-site.dev/", "```", "````"].join(
+        "\n",
+      ),
+    ),
+    [],
+  );
+});
+
+test("an indented fence still opens a block", () => {
+  // Up to three spaces of indentation is still a fence, not an indented block.
+  assert.deepEqual(
+    urlsIn(["   ```", "   https://inside.vendor-site.dev/", "   ```"].join("\n")),
+    [],
+  );
+});
+
+test("skips a URL inside an inline code span", () => {
+  assert.deepEqual(
+    urlsIn(
+      "Point the browser at `http://ip.address.of.device/calib.dat` first.",
+    ),
+    [],
+  );
+});
+
+test("an inline span does not hide a link elsewhere on the same line", () => {
+  assert.deepEqual(
+    urlsIn(
+      "Use `http://DEVICE_IP/json`, described at https://esphome.io/components/rest.",
+    ),
+    ["https://esphome.io/components/rest"],
+  );
+});
+
+test("still skips reserved and placeholder hostnames", () => {
+  // Unchanged behaviour, pinned so the fence work above cannot quietly
+  // replace the SKIP list rather than adding to it.
+  assert.deepEqual(
+    urlsIn(
+      [
+        "http://localhost:8080/",
+        "https://192.168.1.4/",
+        "https://www.example.com/",
+        "https://device.local/",
+        "https://github.com/octocat/Hello-World",
+      ].join("\n\n"),
+    ),
+    [],
+  );
+});
+
+test("trailing punctuation is not part of the URL", () => {
+  assert.deepEqual(urlsIn("Read https://esphome.io/page."), [
+    "https://esphome.io/page",
+  ]);
+});
+
+test("the same URL in two files records both locations", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "check-links-"));
+  const a = path.join(dir, "a.md");
+  const b = path.join(dir, "b.md");
+  fs.writeFileSync(a, "https://esphome.io/shared\n", "utf8");
+  fs.writeFileSync(b, "https://esphome.io/shared\n", "utf8");
+  try {
+    assert.equal(
+      extractUrls([a, b]).get("https://esphome.io/shared")?.length,
+      2,
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -29,10 +29,20 @@
  * CI and treated as explicit example/placeholder URLs. Links to GitHub's
  * `octocat` mascot account (github.com/octocat/...) are skipped for the
  * same reason - they are conventional placeholders, not real resources.
+ *
+ * Code is skipped too - fenced blocks and inline spans. A URL there is not
+ * a link: it renders as literal text nobody can click, so a dead one is
+ * not a broken link on the site. Device pages are mostly one large YAML
+ * config block, which carries two kinds of URL this checker can never
+ * usefully report - placeholders the reader substitutes
+ * (`resource: http://DEVICE_IP/json`) and vendor pages cited in a YAML
+ * comment above a copy-pasted config. Both are pinned to whatever the
+ * config author saw, and neither is a link the site offers a visitor.
  */
 
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 interface Location {
   file: string;
@@ -137,12 +147,47 @@ function selectFiles(): string[] {
   return changedMarkdownFiles();
 }
 
-function extractUrls(files: string[]): Map<string, Location[]> {
+// A fenced code block delimiter: three or more backticks or tildes, indented
+// by at most three spaces (CommonMark). The closing fence must use the same
+// character and be at least as long as the opening one, so ``` inside a ~~~
+// block - or a shorter run inside a longer fence - does not end it early.
+const FENCE = /^ {0,3}(`{3,}|~{3,})/;
+// Inline code: `like this`, or ``like `this` `` when the content has a
+// backtick of its own. Stripped before matching so a URL in a code span is
+// treated the same as one in a fenced block.
+const INLINE_CODE = /(`+)[^`]*?\1/g;
+
+/**
+ * Strip the parts of a markdown line that render as code rather than a link.
+ *
+ * Only inline spans need per-line work; fenced blocks are handled by the
+ * caller, which has to track state across lines.
+ */
+function withoutInlineCode(line: string): string {
+  return line.replace(INLINE_CODE, "");
+}
+
+export function extractUrls(files: string[]): Map<string, Location[]> {
   const locations = new Map<string, Location[]>();
   for (const file of files) {
     const lines = readFileSync(file, "utf8").split("\n");
+    // The opening delimiter of the fence currently open, or null outside one.
+    let fence: string | null = null;
     lines.forEach((lineText, i) => {
-      for (const m of lineText.matchAll(URL_RE)) {
+      const delimiter = lineText.match(FENCE)?.[1];
+      if (delimiter) {
+        if (fence === null) {
+          fence = delimiter;
+        } else if (
+          delimiter[0] === fence[0] &&
+          delimiter.length >= fence.length
+        ) {
+          fence = null;
+        }
+        return;
+      }
+      if (fence !== null) return;
+      for (const m of withoutInlineCode(lineText).matchAll(URL_RE)) {
         const url = m[0].replace(TRAIL, "");
         if (SKIP.test(url)) continue;
         const arr = locations.get(url) ?? [];
@@ -290,4 +335,11 @@ async function main(): Promise<number> {
   return 0;
 }
 
-process.exit(await main());
+// Only run when invoked directly. The unit tests import `extractUrls`, and a
+// bare top-level call would run the whole checker on import.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  process.exit(await main());
+}


### PR DESCRIPTION
Refs #1576.

Not one of the 82 entries — a change to the checker that removes 13 of them and stops them recurring every week.

## The problem

`extractUrls` scans every line, including fenced code blocks. A URL there is not a link: it renders as literal text nobody can click, so a dead one is not a broken link on the site.

Device pages are mostly one large YAML config block, and those blocks carry two kinds of URL the report can never usefully act on:

- **placeholders the reader substitutes** — `resource: http://DEVICE_IP/json` in `esp-hydropony-light-monitor`, `url: http://url.to.my.http/api/` in `myStrom-Wifi-Button`. Both are `fetch failed` rows on #1576 and both always will be; there is no URL that would make them pass.
- **vendor pages cited in a YAML comment above a copy-pasted config** — `# Basic Config` followed by `# https://mirabellagenio.net.au/smart-ir-controller`. Pinned to whatever the config author saw, and nobody can update the citation without changing what the comment says.

This is the reasoning the SKIP list is already built on. The header comment says reserved and private hostnames are "treated as explicit example/placeholder URLs" — but that only catches placeholders whose shape happens to be RFC-reserved, and `DEVICE_IP` is not.

## Measured

On the current tree, whole-repo scan:

| | URLs examined |
|---|---|
| before | 1276 |
| after | 1095 |

**13 of the 82 entries on #1576** are only ever reachable inside code:

```
http://url.to.my.http/api/
http://DEVICE_IP/json
https://www.zemismart.com/zemismart-e27-6w-...-p0040.html
https://blakadder.github.io/templates/novostella_20W_flood.html
https://devices.esphome.io/devices/Mirabella-Genio
https://www.mirabellagenio.com.au/product-range/...-9w-led-gls-bulb/
https://mirabellagenio.net.au/es-%2F-bc-cool-white-specs
https://mirabellagenio.net.au/smart-ir-controller
https://mirabellagenio.net.au/wi-fi-led-a70-1400-lumen
https://mirabellagenio.net.au/door-%26-window-sensor
https://www.lohas-led.com/lohas-smart-led-bulb-a21-...-p0230.html
https://www.lohas-led.com/lohas-smart-led-light-bulbs-...-p0238.html
https://brilliantlighting.com.au/product/smart-wifi-plug-with-usb-charger-8e7c49
```

## This is a judgment call, and easy to narrow

The case against: you may still want to know when a vendor URL in an example config has died, so a contributor can refresh it. That is legitimate, and if that is your view the right shape is narrower — skip only placeholder-looking hosts inside fences, or keep fenced URLs but report them in a separate section of the weekly issue rather than as broken links. Happy to rework it either way.

What tipped me toward skipping the block wholesale is that a contributor triaging the weekly report cannot act on either kind. Sixteen percent of the list is noise that regenerates every week, and noise that regenerates is what makes a report stop being read.

## Also on the maintainer's allowlist question

@breti asked above about allowlisting `developer.tuya.com` and `www.delock.de`. This does not address that — those are prose links and stay checked. There is no allowlist mechanism at all right now; it would be a small addition (a `SKIP`-adjacent list, or a file the workflow reads) and I am glad to open it separately if you want it. It seemed better as its own PR than bundled here.

## Details

Fence handling follows CommonMark rather than matching a bare ` ``` `: the closing fence must use the same character and be at least as long as the opening one, and up to three spaces of indentation still opens a block. Inline spans are stripped per line, so a URL in ```http://DEVICE_IP/json``` is skipped while a real link later on the same line is not.

`extractUrls` is exported and the top-level `process.exit(await main())` is guarded to direct invocation, so the tests can import it without running the whole checker.

## Tests

New `scripts/check-links.test.ts`, 13 cases, in the `node:test` style of `workflow-scripts.test.ts` and picked up by `npm test` as-is: prose links still found and line numbers still right, fenced and inline code skipped, checking resumes after a fence closes, tilde fences, a shorter fence not closing a longer one, indented fences, and the SKIP list still doing its job.

Worth flagging: the fixtures deliberately avoid `example.com`. My first draft used it throughout and every fence test passed **before** the fence code existed, because `example.*` is already in `SKIP`.

`npm test` — 60 passed, 2 skipped, 0 failed.