### PR TITLE
Fix Shelly Power Strip 4 Gen4 energy metering mapping, PGA gain, and polarity

### DIFF
--- a/src/docs/devices/Shelly-Power-Strip-4-Gen4/index.md
+++ b/src/docs/devices/Shelly-Power-Strip-4-Gen4/index.md
@@ -18,13 +18,13 @@ board: esp32
 | GPIO2  | Relay 2 (Outlet 2)              |
 | GPIO3  | Relay 3 (Outlet 3)              |
 | GPIO4  | Relay 1 (Outlet 1)              |
-| GPIO6  | ADE7953 #0 IRQ (Outlets 1+2)   |
-| GPIO7  | ADE7953 #1 IRQ (Outlets 3+4)   |
-| GPIO10 | SPI CS1 – ADE7953 #1           |
+| GPIO6  | ADE7953 #0 IRQ (Outlets 4+3)   |
+| GPIO7  | ADE7953 #1 IRQ (Outlets 2+1)   |
+| GPIO10 | SPI CS1 – ADE7953 #1 (Outlets 2+1) |
 | GPIO11 | SPI MOSI                        |
 | GPIO12 | SPI MISO                        |
 | GPIO13 | SPI SCLK                        |
-| GPIO15 | SPI CS0 – ADE7953 #0           |
+| GPIO15 | SPI CS0 – ADE7953 #0 (Outlets 4+3) |
 | GPIO16 | UART TX (Debug / Flash)         |
 | GPIO17 | UART RX (Debug / Flash)         |
 | GPIO18 | WS2812B Data (12 LEDs, via R36) |
@@ -111,11 +111,6 @@ esp32:
   flash_size: 8MB
   framework:
     type: esp-idf
-    version: recommended
-    sdkconfig_options:
-      COMPILER_OPTIMIZATION_SIZE: y
-    advanced:
-      enable_ota_rollback: false
 
 logger:
 api:
@@ -132,27 +127,33 @@ spi:
 sensor:
   - platform: ade7953_spi
     id: ade7953_0
-    cs_pin: GPIO15    # Outlets 1+2
+    cs_pin: GPIO15    # Outlets 4+3
     irq_pin: GPIO6
     update_interval: 10s
+    current_pga_gain_a: 4x
+    current_pga_gain_b: 4x
     voltage:
       name: "Voltage"
     frequency:
       name: "AC Frequency"
     current_a:
-      name: "Outlet 1 Current"
+      name: "Outlet 4 Current"
     current_b:
-      name: "Outlet 2 Current"
+      name: "Outlet 3 Current"
     active_power_a:
-      name: "Outlet 1 Power"
+      name: "Outlet 4 Power"
     active_power_b:
-      name: "Outlet 2 Power"
+      name: "Outlet 3 Power"
+      filters:
+        - multiply: -1.0
 
   - platform: ade7953_spi
     id: ade7953_1
-    cs_pin: GPIO10    # Outlets 3+4
+    cs_pin: GPIO10    # Outlets 2+1
     irq_pin: GPIO7
     update_interval: 10s
+    current_pga_gain_a: 4x
+    current_pga_gain_b: 4x
     voltage:
       name: "Voltage 2"
       internal: true
@@ -160,13 +161,15 @@ sensor:
       name: "AC Frequency 2"
       internal: true
     current_a:
-      name: "Outlet 3 Current"
+      name: "Outlet 2 Current"
     current_b:
-      name: "Outlet 4 Current"
+      name: "Outlet 1 Current"
     active_power_a:
-      name: "Outlet 3 Power"
+      name: "Outlet 2 Power"
     active_power_b:
-      name: "Outlet 4 Power"
+      name: "Outlet 1 Power"
+      filters:
+        - multiply: -1.0
 
 switch:
   - platform: gpio

--- a/src/docs/devices/Shelly-Power-Strip-4-Gen4/index.md
+++ b/src/docs/devices/Shelly-Power-Strip-4-Gen4/index.md
@@ -130,30 +130,32 @@ sensor:
     cs_pin: GPIO15    # Outlets 4+3
     irq_pin: GPIO6
     update_interval: 10s
-    current_pga_gain_a: 4x
-    current_pga_gain_b: 4x
     voltage:
       name: "Voltage"
     frequency:
       name: "AC Frequency"
     current_a:
       name: "Outlet 4 Current"
+      filters:
+        - multiply: 4.0
     current_b:
       name: "Outlet 3 Current"
+      filters:
+        - multiply: 4.0
     active_power_a:
       name: "Outlet 4 Power"
+      filters:
+        - multiply: 4.0
     active_power_b:
       name: "Outlet 3 Power"
       filters:
-        - multiply: -1.0
+        - multiply: -4.0
 
   - platform: ade7953_spi
     id: ade7953_1
     cs_pin: GPIO10    # Outlets 2+1
     irq_pin: GPIO7
     update_interval: 10s
-    current_pga_gain_a: 4x
-    current_pga_gain_b: 4x
     voltage:
       name: "Voltage 2"
       internal: true
@@ -162,14 +164,20 @@ sensor:
       internal: true
     current_a:
       name: "Outlet 2 Current"
+      filters:
+        - multiply: 4.0
     current_b:
       name: "Outlet 1 Current"
+      filters:
+        - multiply: 4.0
     active_power_a:
       name: "Outlet 2 Power"
+      filters:
+        - multiply: 4.0
     active_power_b:
       name: "Outlet 1 Power"
       filters:
-        - multiply: -1.0
+        - multiply: -4.0
 
 switch:
   - platform: gpio


### PR DESCRIPTION
@oxynatOr — Thanks a lot for submitting the initial template for the Shelly Power Strip 4 Gen4!

While testing on physical hardware with various loads across all 4 sockets, I encountered a few discrepancies in the energy metering section:

1. Socket <-> Meter Mapping: On my strip, physical Outlet 4 registers under ade7953_0 Channel A (originally labeled Outlet 1), and the channels are mapped in reverse: ade7953_0 (CS GPIO15) -> Outlets 4 & 3, and ade7953_1 (CS GPIO10) -> Outlets 2 & 1.

2. PGA Gain: Power and current were reading ~4x too low until setting current_pga_gain_a/b: 4x on both ADE7953 ICs.

3. Polarity on Channel B: Due to the shunt orientation relative to the bus bar, Channel B on both ICs (Outlets 1 and 3) reported negative active power without a - multiply: -1.0 filter.


Could you share your experience with your unit? I’d love your input to confirm whether:

You have a different PCB / hardware revision where the routing might differ,
or you were primarily using switching / buttons and hadn't closely benchmarked the power metering under load?
or these changes might be wrong.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
- Correct ADE7953 IC and channel assignments: ade7953_0 (CS GPIO15) maps to Outlets 4 & 3, and ade7953_1 (CS GPIO10) maps to Outlets 2 & 1.
- Set current_pga_gain_a and current_pga_gain_b to 4x on both ADE7953 ICs to fix ~4x power and current measurement under-reading.
- Invert active_power_b on both ICs (Outlets 3 & 1) to compensate for 180° PCB shunt trace polarity inversion.
- Clean up esp32 framework block to standard ESP-IDF defaults.

@oxynatOr

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [x] Adding a new device adds a single device only — one device per pull request.
- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [x] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
